### PR TITLE
Updated to use cf-grunt-config.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,201 +2,94 @@ module.exports = function(grunt) {
 
   'use strict';
 
+  require('time-grunt')(grunt);
+
   var path = require('path');
 
-  grunt.initConfig({
 
-    pkg: grunt.file.readJSON('package.json'),
+  /**
+   * Load the tasks we want to use, which are specified as dependencies in
+   * the package.json file of cf-grunt-config.
+   */
 
-    bower: {
-      install: {
-        options: {
-          targetDir: 'src/vendor/',
-          install: true,
-          verbose: true,
-          cleanBowerDir: true,
-          cleanTargetDir: true,
-          layout: function(type, component) {
-            if (type === 'img') {
-              return path.join('../../demo/static/img');
-            } else if (type === 'fonts') {
-              return path.join('../../demo/static/fonts');
-            } else {
-              return path.join(component);
-            }
-          }
-        }
-      }
-    },
-
-    clean: {
-      vendor: [
-        'src/vendor/cf-concat/cf.less'
-      ]
-    },
-
-    concat: {
-      main: {
-        src: [
-          'src/*.less',
-          'src/vendor/cf-*/*.less',
-          'src/vendor/font-awesome/font-awesome.css'
-        ],
-        dest: 'src/vendor/cf-concat/cf.less',
-      },
-    },
-
-    less: {
-      main: {
-        options: {
-          paths: grunt.file.expand('src/vendor/**/'),
-          yuicompress: false
-        },
-        files: {
-          'demo/static/css/main.css': [
-            'src/vendor/normalize-css/normalize.css',
-            'src/vendor/cf-concat/cf.less'
-          ]
-        }
-      }
-    },
-
-    'string-replace': {
-      vendor: {
-        files: {
-          'demo/static/css/': ['demo/static/css/main.css']
-        },
-        options: {
-          replacements: [{
-            pattern: /url\((.*?)\)/ig,
-            replacement: function (match, p1, offset, string) {
-              var path, pathParts, pathLength, filename, newPath;
-              path = p1.replace(/["']/g,''); // Removes quotation marks if there are any
-              pathParts = path.split('/'); // Splits the path so we can find the filename
-              pathLength = pathParts.length;
-              filename = pathParts[pathLength-1]; // The filename is the last item in pathParts
-
-              grunt.verbose.writeln('');
-              grunt.verbose.writeln('--------------');
-              grunt.verbose.writeln('Original path:');
-              grunt.verbose.writeln(match);
-              grunt.verbose.writeln('--------------');
-
-              // Rewrite the path based on the file type
-              // Note that .svg can be a font or a graphic, not usre what to do about this.
-              if (filename.indexOf('.eot') !== -1 ||
-                  filename.indexOf('.woff') !== -1 ||
-                  filename.indexOf('.ttf') !== -1 ||
-                  filename.indexOf('.svg') !== -1)
-              {
-                newPath = 'url("../fonts/'+filename+'")';
-                grunt.verbose.writeln('New path:');
-                grunt.verbose.writeln(newPath);
-                grunt.verbose.writeln('--------------');
-                return newPath;
-              } else if (filename.indexOf('.png') !== -1 ||
-                  filename.indexOf('.gif') !== -1 ||
-                  filename.indexOf('.jpg') !== -1)
-              {
-                newPath = 'url("../img/'+filename+'")';
-                grunt.verbose.writeln('New path:');
-                grunt.verbose.writeln(newPath);
-                grunt.verbose.writeln('--------------');
-                return newPath;
-              } else {
-                grunt.verbose.writeln('No new path.');
-                grunt.verbose.writeln('--------------');
-                return match;
-              }
-
-              grunt.verbose.writeln('--------------');
-              return match;
-            }
-          }]
-        }
-      }
-    },
-
-    autoprefixer: {
-      options: {
-        // Options we might want to enable in the future.
-        diff: false,
-        map: false
-      },
-      multiple_files: {
-        // Prefix all CSS files found in `src/static/css` and overwrite.
-        expand: true,
-        src: 'demo/static/css/main.css'
-      },
-    },
-
-    copy: {
-      docs_assets: {
-        files:
-        [{
-          expand: true,
-          cwd: 'demo/',
-          src: ['static/img/**', 'static/fonts/**'],
-          dest: 'docs/'
-        }]
-      },
-      docs: {
-        files:
-        [{
-          expand: true,
-          cwd: 'demo/',
-          src: ['static/css/main.css'],
-          dest: 'docs/'
-        }]
-      }
-    },
-
-    topdoc: {
-      test: {
-        options: {
-          source: 'demo/static/css/',
-          destination: 'demo/',
-          template: 'node_modules/cf-component-demo/' + ( grunt.option('tpl') || 'raw' ) + '/',
-          templateData: {
-            family: '<%= pkg.name %>',
-            title: '<%= pkg.name %> demo',
-            repo: '<%= pkg.homepage %>'
-          }
-        }
-      },
-      docs: {
-        options: {
-          source: 'docs/static/css/',
-          destination: 'docs/',
-          template: 'node_modules/cf-component-demo/' + ( grunt.option('tpl') || 'code_examples' ) + '/',
-          templateData: {
-            family: '<%= pkg.name %>',
-            title: '<%= pkg.name %> docs',
-            repo: '<%= pkg.homepage %>'
-          }
-        }
-      }
-    }
-
+  // Sets the CWD to the cf-grunt-config package so that the loadTasks method
+  // (employed in jit-grunt) looks in the correct place.
+  grunt.file.setBase('./node_modules/cf-grunt-config/');
+  // Loads all Grunt tasks in the node_modules directory within the new CWD.
+  require('jit-grunt')(grunt, {
+    // Below line needed because task name does not match package name
+    bower: 'grunt-bower-task'
   });
+  // Sets the CWD back to the project root so that the tasks work as expected.
+  grunt.file.setBase('../../');
+
 
   /**
-   * The above tasks are loaded here.
+   * Initialize a variable to represent the Grunt task configuration.
    */
-  grunt.loadNpmTasks('grunt-autoprefixer');
-  grunt.loadNpmTasks('grunt-bower-task');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-less');
-  grunt.loadNpmTasks('grunt-string-replace');
-  grunt.loadNpmTasks('grunt-topdoc');
+  var config = {
+
+    // Define a couple of utility variables that may be used in task options.
+    pkg: grunt.file.readJSON('package.json'),
+    env: process.env,
+    opt: {
+      // Include path to compiled extra CSS for IE7 and below.
+      // Definitely needed if this component depends on an icon font.
+      // ltIE8Source: 'static/css/main.lt-ie8.min.css',
+
+      // Include path to compiled alternate CSS for IE8 and below.
+      // Definitely needed if this component depends on media queries.
+      // ltIE9AltSource: 'static/css/main.lt-ie9.min.css',
+
+      // Set whether or not to include html5shiv for demoing a component.
+      // Only necessary if component patterns include new HTML5 elements
+      html5Shiv: false,
+    },
+
+    // Define tasks specific to this project here
+
+  };
+
 
   /**
-   * Create custom task aliases and combinations
+   * Define a function that, given the path argument, returns an object
+   * containing all JS files in that directory.
    */
-  grunt.registerTask('all', ['clean', 'bower', 'copy:docs_assets', 'concat', 'less', 'string-replace', 'copy:docs', 'topdoc:test', 'topdoc:docs']);
-  grunt.registerTask('vendor', ['clean', 'bower', 'copy:docs_assets', 'concat']);
-  grunt.registerTask('default', ['clean', 'concat', 'less', 'string-replace', 'autoprefixer', 'copy:docs', 'topdoc:test', 'topdoc:docs']);
+  function loadConfig(path) {
+    var glob = require('glob');
+    var object = {};
+    var key;
+
+    glob.sync('*', {cwd: path}).forEach(function(option) {
+      key = option.replace(/\.js$/,'');
+      object[key] = require(path + option);
+      grunt.verbose.writeln("External config item - " + key + ": " + object[key]);
+    });
+
+    return object;
+  }
+
+
+  /**
+   * Combine the config variable defined above with the results of calling the
+   * loadConfig function with the given path, which is where our external
+   * task options get installed by npm.
+   */
+  grunt.util._.extend(config, loadConfig('./node_modules/cf-grunt-config/tasks/options/'));
+
+  grunt.initConfig(config);
+
+
+  /**
+   * Load any project-specific tasks installed in the customary location.
+   */
+  require('load-grunt-tasks')(grunt);
+
+
+  /**
+   * Create custom task aliases for our component build workflow.
+   */
+  grunt.registerTask('vendor', ['bower', 'copy:component_assets', 'copy:docs_assets', 'concat']);
+  grunt.registerTask('default', ['concat', 'less', 'string-replace', 'autoprefixer', 'copy:docs', 'topdoc']);
 
 };

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,7 +13,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="static/css/main.css">
   </head>
-  <body>
+  <body style="padding:4px;">
     <div id="singlemulti-line-text-inputs">
       <div>
         <div>
@@ -60,6 +60,11 @@
 </div><br>
       </div>
     </div>
-    <div id="custom-demo"></div>
+    <div id="custom-demo">
+<!--
+<hr><br>
+Add custom demo HTML here
+-->
+</div>
   </body>
 </html>

--- a/demo/static/css/main.css
+++ b/demo/static/css/main.css
@@ -1,490 +1,3 @@
-/* ==========================================================================
-   Capital Framework
-   Form Element Styling
-   ========================================================================== */
-label {
-  display: block;
-}
-/* topdoc
-    name: Single/Multi-Line Text Inputs
-    family: cf-forms
-    patterns:
-    - name: Default single-line text input
-      markup: |
-        <input placeholder="placeholder text" type="text">
-    - name: Focused single-line text input
-      markup: |
-        <input class="focus" placeholder="placeholder text" type="text">
-    - name: Field in error state
-      codenotes:
-        - 'role="alert"'
-      notes:
-        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
-      markup: |
-        <input class="error" type="text" value="Invalid input">
-        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
-    - name: Field in success state
-      markup: |
-        <input class="success" type="text" value="Validated input">
-        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
-    - name: Default multi-line text box
-      markup: |
-        <textarea>Example entry</textarea>
-    - name: Focused multi-line text box
-      markup: |
-        <textarea class="focus">Example entry</textarea>
-    - name: Multi-line text box in error state
-      codenotes:
-        - 'role="alert"'
-      notes:
-        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
-      markup: |
-        <textarea class="error">Invalid input</textarea>
-        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
-    - name: Multi-line text box in success state
-      markup: |
-        <textarea class="success">Validated input</textarea>
-        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
-    tags:
-    - cf-forms
-*/
-input,
-textarea {
-  display: inline-block;
-  width: 85%;
-  margin: 0;
-  padding: 0.25em;
-  font-family: Arial, sans-serif;
-  font-size: 1em;
-  background: #ffffff;
-  border: 1px solid #75787b;
-  border-radius: 0;
-  vertical-align: top;
-  -webkit-appearance: none;
-  -webkit-user-modify: read-write-plaintext-only;
-}
-textarea {
-  overflow: auto;
-}
-input:focus,
-input.focus,
-textarea:focus,
-textarea.focus {
-  border: 1px solid #0072ce;
-  border-color: #0072ce;
-  outline: 1px solid #0072ce;
-  outline-offset: 0;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
-input.error,
-textarea.error {
-  border: 1px solid #d12124;
-  outline: 1px solid #d12124;
-}
-input.success,
-textarea.success {
-  border: 1px solid #2cb34a;
-  outline: 1px solid #2cb34a;
-}
-input + [class^="icon-"],
-textarea + [class^="icon-"] {
-  position: relative;
-  top: 0.15em;
-  margin-left: 0.2em;
-  font-size: 1.25em;
-}
-.error + [class^="icon-"] {
-  color: #d12124;
-}
-.success + [class^="icon-"] {
-  color: #2cb34a;
-}
-/* topdoc
-  name: EOF
-  eof: true
-*/
-/* ==========================================================================
-   Capital Framework
-   Color Variables
-   ========================================================================== */
-/* ==========================================================================
-   Capital Framework
-   Basic Typography
-   ========================================================================== */
-/* topdoc
-    name: LESS notes
-    family: cf-typography
-    patterns:
-    - name: Size variables
-      codenotes:
-        - "@base-font-size-px: 16px;"
-        - "@base-line-height-px: 22px;"
-        - "@base-line-height: unit(@base-line-height-px / @base-font-size-px);"
-    - name: Webfont mixins
-      codenotes:
-        - ".webfont-regular()"
-        - ".webfont-italic()"
-        - ".webfont-medium()"
-        - ".webfont-demi()"
-    - name: Explicitly set font styles
-      notes:
-        - "Any instances of Avenir Next getting italicized or bolded must be declared explicitly
-          so that it uses the correct webfont and does not fake the style on normal Avenir Next."
-        - "Use the webfont mixins above to make this easy. See the #blockquote styles as an example."
-      markup: |
-       <blockquote cite="http://cfpb.github.io/cf-typography/docs/index.html#webfont-notes">
-         Any instances of Avenir Next getting <em>italic</em><i>ized</i> or <strong>bold</strong><b>ed</b> must be declared explicitly ...
-       </blockquote> 
-    tags:
-    - cf-typography
-*/
-/* topdoc
-    name: Type hierarchy
-    family: cf-typography
-    patterns:
-    - name: Default body type
-      markup: |
-        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-    - name: Heading level 1
-      markup: |
-        <h1>Example heading element</h1>
-        <p class="h1">A non-heading element</p>
-    - name: Heading level 2
-      markup: |
-        <h2>Example heading element</h2>
-        <p class="h2">A non-heading element</p>
-    - name: Heading level 3
-      markup: |
-        <h3>Example heading element</h3>
-        <p class="h3">A non-heading element</p>
-    - name: Heading level 4
-      markup: |
-        <h4>Example heading element</h4>
-        <p class="h4">A non-heading element</p>
-    - name: Heading level 5
-      markup: |
-        <h5>Example heading element</h5>
-        <p class="h5">A non-heading element</p>
-    - name: Heading level 6
-      markup: |
-        <h6>Example heading element</h6>
-        <p class="h6">A non-heading element</p>
-    - name: Super header
-      markup: |
-        <h1 class="superheader">Example super heading</h1>
-        <p class="superheader">Example super heading</p>
-    tags:
-    - cf-typography
-*/
-body {
-  color: #101820;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 100%;
-  line-height: 1.375;
-}
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
-.h6 {
-  margin-top: 0;
-  font-family: "Avenir Next", Arial, sans-serif;
-  font-style: normal;
-  font-weight: normal;
-}
-h1,
-.h1 {
-  margin-bottom: 0.6470588235294118em;
-  font-size: 2.125em;
-  line-height: 1.2941176470588236;
-}
-h2,
-.h2 {
-  margin-bottom: 0.8461538461538461em;
-  font-size: 1.625em;
-  line-height: 1.2692307692307692;
-}
-h3,
-.h3 {
-  margin-bottom: 1em;
-  font-size: 1.375em;
-  line-height: 1.2727272727272727;
-}
-h4,
-.h4 {
-  font-family: "Avenir Next Medium", Arial, sans-serif;
-  font-style: normal;
-  font-weight: 500;
-  margin-bottom: 1.2222222222222223em;
-  font-size: 1.125em;
-  line-height: 1.2222222222222223;
-}
-h5,
-h6,
-.h5,
-.h6 {
-  font-family: "Avenir Next Demi", Arial, sans-serif;
-  font-style: normal;
-  font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-}
-h5,
-.h5 {
-  margin-bottom: 1.5714285714285714em;
-  font-size: 0.875em;
-  line-height: 1.5714285714285714;
-}
-h6,
-.h6 {
-  margin-bottom: 1.8333333333333333em;
-  font-size: 0.75em;
-  line-height: 1.8333333333333333;
-}
-.superheader {
-  font-family: "Avenir Next Demi", Arial, sans-serif;
-  font-style: normal;
-  font-weight: bold;
-  margin-bottom: 0.4583333333333333em;
-  font-size: 3em;
-  line-height: 1.375;
-}
-/* topdoc
-    name: Margins
-    family: cf-typography
-    patterns:
-    - name: Consistent vertical margins
-      notes:
-        - "Assumes that the font size of each of these items remains the default."
-      markup: |
-        <p>Paragraph margin example</p>
-        <p>Paragraph margin example</p>
-    tags:
-    - cf-typography
-*/
-p,
-ul,
-ol,
-dl,
-table,
-blockquote,
-figure {
-  margin-top: 0;
-  margin-bottom: 1.375em;
-}
-/* topdoc
-    name: Default link
-    notes:
-      - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not 
-        be used in production."
-    family: cf-typography
-    patterns:
-    - name: Default state
-      markup: |
-        <a href="#">Default link style</a>
-    - name: Visited state
-      markup: |
-        <a href="#" class="visited">Visited link style</a>
-    - name: Hovered state
-      markup: |
-        <a href="#" class="hover">Hovered link style</a>
-    - name: Focused state
-      markup: |
-        <a href="#" class="focus">Focused link style</a>
-    - name: Active state
-      markup: |
-        <a href="#" class="active">Active link style</a>
-    tags:
-    - cf-typography
-*/
-a {
-  border-bottom-width: 0;
-  border-bottom-style: dotted;
-  border-bottom-color: #0072ce;
-  color: #0072ce;
-  text-decoration: none;
-}
-a:visited,
-a.visited {
-  border-bottom-color: #005e5d;
-  color: #005e5d;
-}
-a:hover,
-a.hover {
-  border-bottom-style: solid;
-  border-bottom-color: #7fb8e6;
-  color: #7fb8e6;
-}
-a:focus,
-a.focus {
-  border-bottom-style: solid;
-}
-a:active,
-a.active {
-  border-bottom-style: solid;
-  border-bottom-color: #002d72;
-  color: #002d72;
-}
-/* topdoc
-    name: Underlined links
-    family: cf-typography
-    patterns:
-    - name: States
-      notes:
-        - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not 
-          be used in production."
-        - "The underline style properties are mostly set above in the a tag.
-          To enable the underline simply set a bottom-border-width as done here."
-      markup: |
-        <p>
-            <a href="#">Default</a>,
-            <a href="#" class="visited">Visited</a>,
-            <a href="#" class="hover">Hovered</a>,
-            <a href="#" class="focus">Focused</a>,
-            <a href="#" class="active">Active</a>
-        </p>
-    - name: Underline conditions
-      notes:
-       - "We're restricting link borders to links within p, li, and dd so that
-         we don't have to override them every time we want a plain link."
-      markup: |
-        <p>
-            <a href="#">A child of a paragraph</a>
-        </p>
-        <ul>
-            <li>
-                <a href="#">A child of a list item</a>
-            </li>
-        </ul>
-        <dl>
-            <dt>
-                Definition list term
-            </dt>
-            <dd>
-                <a href="#">A child of a definition list description</a>
-            </dd>
-        </dl>
-    - name: Exceptions for underlined links
-      notes:
-        - "Inline text links inside of a nav element are not underlined."
-      markup: |
-        <nav>
-            <p>
-                <a href="#">A child of a paragraph</a>
-            </p>
-            <ul>
-                <li>
-                    <a href="#">A child of a list item</a>
-                </li>
-            </ul>
-            <dl>
-                <dt>
-                    Definition list term
-                </dt>
-                <dd>
-                    <a href="#">A child of a definition list description</a>
-                </dd>
-            </dl>
-        </nav>
-    tags:
-    - cf-typography
-*/
-p a,
-li a,
-dd a {
-  border-bottom-width: 1px;
-}
-nav a {
-  border-bottom-width: 0;
-}
-/* topdoc
-    name: Blockquote
-    family: cf-typography
-    patterns:
-    - name: Default blockquote
-      markup: |
-       <blockquote>
-         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi animi facere modi eaque amet odio!
-       </blockquote> 
-    tags:
-    - cf-typography
-*/
-blockquote {
-  padding: 0.5em 0.75em;
-  border-left: 4px solid #2cb34a;
-  background: #addc91;
-  font-family: "Avenir Next", Arial, sans-serif;
-  font-style: normal;
-  font-weight: normal;
-}
-blockquote em,
-blockquote i {
-  font-family: "Avenir Next Italic", Arial, sans-serif;
-  font-style: italic;
-  font-weight: normal;
-}
-blockquote strong,
-blockquote b {
-  font-family: "Avenir Next Demi", Arial, sans-serif;
-  font-style: normal;
-  font-weight: bold;
-}
-/* topdoc
-    name: Lists
-    family: cf-typography
-    patterns:
-    - name: Unordered list
-      markup: |
-       <ul>
-         <li>List item</li>
-         <li>List item</li>
-         <li>List item</li>
-       </ul>
-    tags:
-    - cf-typography
-*/
-ul {
-  list-style: square;
-}
-/* topdoc
-    name: IE overrides
-    family: cf-typography
-    patterns:
-    - name: Prevent faux/double bold and italics in IE 6-8
-      notes:
-        - "Any bold or italic Avenir elements added to the base styles MUST BE added to this section, as well."
-        - "Dependent on using H5BP's conditional classes on the <html> element:
-          https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md"
-      markup: |
-        <h5>I might appear as faux/double bold in older IE without this fix.</h5>
-    tags:
-    - cf-typography
-    - ltie9
-*/
-.lt-ie9 h1,
-.lt-ie9 h2,
-.lt-ie9 h3,
-.lt-ie9 h4,
-.lt-ie9 h5,
-.lt-ie9 h6,
-.lt-ie9 blockquote strong {
-  font-weight: normal !important;
-}
-.lt-ie9 blockquote em {
-  font-style: normal !important;
-}
-/* topdoc
-  name: EOF
-  eof: true
-*/
 /*!
  *  Font Awesome 3.2.1
  *  the iconic font designed for Bootstrap
@@ -567,7 +80,7 @@ a [class*=" icon-"] {
 }
 .icons-ul .icon-li {
   position: absolute;
-  left: -2.142857142857143em;
+  left: -2.14285714em;
   width: 2.142857142857143em;
   text-align: center;
   line-height: inherit;
@@ -782,12 +295,10 @@ a .icon-spin {
 @keyframes spin {
   0% {
     -webkit-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
     -webkit-transform: rotate(359deg);
-    -ms-transform: rotate(359deg);
     transform: rotate(359deg);
   }
 }
@@ -1930,3 +1441,491 @@ a .icon-flip-vertical:before {
 .icon-renren:before {
   content: "\f18b";
 }
+
+/* ==========================================================================
+   Capital Framework
+   Form Element Styling
+   ========================================================================== */
+label {
+  display: block;
+}
+/* topdoc
+    name: Single/Multi-Line Text Inputs
+    family: cf-forms
+    patterns:
+    - name: Default single-line text input
+      markup: |
+        <input placeholder="placeholder text" type="text">
+    - name: Focused single-line text input
+      markup: |
+        <input class="focus" placeholder="placeholder text" type="text">
+    - name: Field in error state
+      codenotes:
+        - 'role="alert"'
+      notes:
+        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+      markup: |
+        <input class="error" type="text" value="Invalid input">
+        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
+    - name: Field in success state
+      markup: |
+        <input class="success" type="text" value="Validated input">
+        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
+    - name: Default multi-line text box
+      markup: |
+        <textarea>Example entry</textarea>
+    - name: Focused multi-line text box
+      markup: |
+        <textarea class="focus">Example entry</textarea>
+    - name: Multi-line text box in error state
+      codenotes:
+        - 'role="alert"'
+      notes:
+        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+      markup: |
+        <textarea class="error">Invalid input</textarea>
+        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
+    - name: Multi-line text box in success state
+      markup: |
+        <textarea class="success">Validated input</textarea>
+        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
+    tags:
+    - cf-forms
+*/
+input,
+textarea {
+  display: inline-block;
+  width: 85%;
+  margin: 0;
+  padding: 0.25em;
+  font-family: Arial, sans-serif;
+  font-size: 1em;
+  background: #ffffff;
+  border: 1px solid #75787b;
+  border-radius: 0;
+  vertical-align: top;
+  -webkit-appearance: none;
+  -webkit-user-modify: read-write-plaintext-only;
+}
+textarea {
+  overflow: auto;
+}
+input:focus,
+input.focus,
+textarea:focus,
+textarea.focus {
+  border: 1px solid #0072ce;
+  border-color: #0072ce;
+  outline: 1px solid #0072ce;
+  outline-offset: 0;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+input.error,
+textarea.error {
+  border: 1px solid #d12124;
+  outline: 1px solid #d12124;
+}
+input.success,
+textarea.success {
+  border: 1px solid #2cb34a;
+  outline: 1px solid #2cb34a;
+}
+input + [class^="icon-"],
+textarea + [class^="icon-"] {
+  position: relative;
+  top: 0.15em;
+  margin-left: 0.2em;
+  font-size: 1.25em;
+}
+.error + [class^="icon-"] {
+  color: #d12124;
+}
+.success + [class^="icon-"] {
+  color: #2cb34a;
+}
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Color Variables
+   ========================================================================== */
+/* ==========================================================================
+   Capital Framework
+   Basic Typography
+   ========================================================================== */
+/* topdoc
+    name: LESS notes
+    family: cf-typography
+    patterns:
+    - name: Size variables
+      codenotes:
+        - "@base-font-size-px: 16px;"
+        - "@base-line-height-px: 22px;"
+        - "@base-line-height: unit(@base-line-height-px / @base-font-size-px);"
+    - name: Webfont mixins
+      codenotes:
+        - ".webfont-regular()"
+        - ".webfont-italic()"
+        - ".webfont-medium()"
+        - ".webfont-demi()"
+    - name: Explicitly set font styles
+      notes:
+        - "Any instances of Avenir Next getting italicized or bolded must be declared explicitly
+          so that it uses the correct webfont and does not fake the style on normal Avenir Next."
+        - "Use the webfont mixins above to make this easy. See the #blockquote styles as an example."
+      markup: |
+       <blockquote cite="http://cfpb.github.io/cf-typography/docs/index.html#webfont-notes">
+         Any instances of Avenir Next getting <em>italic</em><i>ized</i> or <strong>bold</strong><b>ed</b> must be declared explicitly ...
+       </blockquote> 
+    tags:
+    - cf-typography
+*/
+/* topdoc
+    name: Type hierarchy
+    family: cf-typography
+    patterns:
+    - name: Default body type
+      markup: |
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    - name: Heading level 1
+      markup: |
+        <h1>Example heading element</h1>
+        <p class="h1">A non-heading element</p>
+    - name: Heading level 2
+      markup: |
+        <h2>Example heading element</h2>
+        <p class="h2">A non-heading element</p>
+    - name: Heading level 3
+      markup: |
+        <h3>Example heading element</h3>
+        <p class="h3">A non-heading element</p>
+    - name: Heading level 4
+      markup: |
+        <h4>Example heading element</h4>
+        <p class="h4">A non-heading element</p>
+    - name: Heading level 5
+      markup: |
+        <h5>Example heading element</h5>
+        <p class="h5">A non-heading element</p>
+    - name: Heading level 6
+      markup: |
+        <h6>Example heading element</h6>
+        <p class="h6">A non-heading element</p>
+    - name: Super header
+      markup: |
+        <h1 class="superheader">Example super heading</h1>
+        <p class="superheader">Example super heading</p>
+    tags:
+    - cf-typography
+*/
+body {
+  color: #101820;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 100%;
+  line-height: 1.375;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  margin-top: 0;
+  font-family: "Avenir Next", Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+h1,
+.h1 {
+  margin-bottom: 0.64705882em;
+  font-size: 2.125em;
+  line-height: 1.29411765;
+}
+h2,
+.h2 {
+  margin-bottom: 0.84615385em;
+  font-size: 1.625em;
+  line-height: 1.26923077;
+}
+h3,
+.h3 {
+  margin-bottom: 1em;
+  font-size: 1.375em;
+  line-height: 1.27272727;
+}
+h4,
+.h4 {
+  font-family: "Avenir Next Medium", Arial, sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  margin-bottom: 1.22222222em;
+  font-size: 1.125em;
+  line-height: 1.22222222;
+}
+h5,
+h6,
+.h5,
+.h6 {
+  font-family: "Avenir Next Demi", Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+h5,
+.h5 {
+  margin-bottom: 1.57142857em;
+  font-size: 0.875em;
+  line-height: 1.57142857;
+}
+h6,
+.h6 {
+  margin-bottom: 1.83333333em;
+  font-size: 0.75em;
+  line-height: 1.83333333;
+}
+.superheader {
+  font-family: "Avenir Next Demi", Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 0.45833333em;
+  font-size: 3em;
+  line-height: 1.375;
+}
+/* topdoc
+    name: Margins
+    family: cf-typography
+    patterns:
+    - name: Consistent vertical margins
+      notes:
+        - "Assumes that the font size of each of these items remains the default."
+      markup: |
+        <p>Paragraph margin example</p>
+        <p>Paragraph margin example</p>
+    tags:
+    - cf-typography
+*/
+p,
+ul,
+ol,
+dl,
+table,
+blockquote,
+figure {
+  margin-top: 0;
+  margin-bottom: 1.375em;
+}
+/* topdoc
+    name: Default link
+    notes:
+      - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not 
+        be used in production."
+    family: cf-typography
+    patterns:
+    - name: Default state
+      markup: |
+        <a href="#">Default link style</a>
+    - name: Visited state
+      markup: |
+        <a href="#" class="visited">Visited link style</a>
+    - name: Hovered state
+      markup: |
+        <a href="#" class="hover">Hovered link style</a>
+    - name: Focused state
+      markup: |
+        <a href="#" class="focus">Focused link style</a>
+    - name: Active state
+      markup: |
+        <a href="#" class="active">Active link style</a>
+    tags:
+    - cf-typography
+*/
+a {
+  border-bottom-width: 0;
+  border-bottom-style: dotted;
+  border-bottom-color: #0072ce;
+  color: #0072ce;
+  text-decoration: none;
+}
+a:visited,
+a.visited {
+  border-bottom-color: #005e5d;
+  color: #005e5d;
+}
+a:hover,
+a.hover {
+  border-bottom-style: solid;
+  border-bottom-color: #7fb8e6;
+  color: #7fb8e6;
+}
+a:focus,
+a.focus {
+  border-bottom-style: solid;
+}
+a:active,
+a.active {
+  border-bottom-style: solid;
+  border-bottom-color: #002d72;
+  color: #002d72;
+}
+/* topdoc
+    name: Underlined links
+    family: cf-typography
+    patterns:
+    - name: States
+      notes:
+        - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not 
+          be used in production."
+        - "The underline style properties are mostly set above in the a tag.
+          To enable the underline simply set a bottom-border-width as done here."
+      markup: |
+        <p>
+            <a href="#">Default</a>,
+            <a href="#" class="visited">Visited</a>,
+            <a href="#" class="hover">Hovered</a>,
+            <a href="#" class="focus">Focused</a>,
+            <a href="#" class="active">Active</a>
+        </p>
+    - name: Underline conditions
+      notes:
+       - "We're restricting link borders to links within p, li, and dd so that
+         we don't have to override them every time we want a plain link."
+      markup: |
+        <p>
+            <a href="#">A child of a paragraph</a>
+        </p>
+        <ul>
+            <li>
+                <a href="#">A child of a list item</a>
+            </li>
+        </ul>
+        <dl>
+            <dt>
+                Definition list term
+            </dt>
+            <dd>
+                <a href="#">A child of a definition list description</a>
+            </dd>
+        </dl>
+    - name: Exceptions for underlined links
+      notes:
+        - "Inline text links inside of a nav element are not underlined."
+      markup: |
+        <nav>
+            <p>
+                <a href="#">A child of a paragraph</a>
+            </p>
+            <ul>
+                <li>
+                    <a href="#">A child of a list item</a>
+                </li>
+            </ul>
+            <dl>
+                <dt>
+                    Definition list term
+                </dt>
+                <dd>
+                    <a href="#">A child of a definition list description</a>
+                </dd>
+            </dl>
+        </nav>
+    tags:
+    - cf-typography
+*/
+p a,
+li a,
+dd a {
+  border-bottom-width: 1px;
+}
+nav a {
+  border-bottom-width: 0;
+}
+/* topdoc
+    name: Blockquote
+    family: cf-typography
+    patterns:
+    - name: Default blockquote
+      markup: |
+       <blockquote>
+         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi animi facere modi eaque amet odio!
+       </blockquote> 
+    tags:
+    - cf-typography
+*/
+blockquote {
+  padding: 0.5em 0.75em;
+  border-left: 4px solid #2cb34a;
+  background: #addc91;
+  font-family: "Avenir Next", Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+blockquote em,
+blockquote i {
+  font-family: "Avenir Next Italic", Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+blockquote strong,
+blockquote b {
+  font-family: "Avenir Next Demi", Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+/* topdoc
+    name: Lists
+    family: cf-typography
+    patterns:
+    - name: Unordered list
+      markup: |
+       <ul>
+         <li>List item</li>
+         <li>List item</li>
+         <li>List item</li>
+       </ul>
+    tags:
+    - cf-typography
+*/
+ul {
+  list-style: square;
+}
+/* topdoc
+    name: IE overrides
+    family: cf-typography
+    patterns:
+    - name: Prevent faux/double bold and italics in IE 6-8
+      notes:
+        - "Any bold or italic Avenir elements added to the base styles MUST BE added to this section, as well."
+        - "Dependent on using H5BP's conditional classes on the <html> element:
+          https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md"
+      markup: |
+        <h5>I might appear as faux/double bold in older IE without this fix.</h5>
+    tags:
+    - cf-typography
+    - ltie9
+*/
+.lt-ie9 h1,
+.lt-ie9 h2,
+.lt-ie9 h3,
+.lt-ie9 h4,
+.lt-ie9 h5,
+.lt-ie9 h6,
+.lt-ie9 blockquote strong {
+  font-weight: normal !important;
+}
+.lt-ie9 blockquote em {
+  font-style: normal !important;
+}
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/docs/static/css/main.css
+++ b/docs/static/css/main.css
@@ -1,490 +1,3 @@
-/* ==========================================================================
-   Capital Framework
-   Form Element Styling
-   ========================================================================== */
-label {
-  display: block;
-}
-/* topdoc
-    name: Single/Multi-Line Text Inputs
-    family: cf-forms
-    patterns:
-    - name: Default single-line text input
-      markup: |
-        <input placeholder="placeholder text" type="text">
-    - name: Focused single-line text input
-      markup: |
-        <input class="focus" placeholder="placeholder text" type="text">
-    - name: Field in error state
-      codenotes:
-        - 'role="alert"'
-      notes:
-        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
-      markup: |
-        <input class="error" type="text" value="Invalid input">
-        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
-    - name: Field in success state
-      markup: |
-        <input class="success" type="text" value="Validated input">
-        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
-    - name: Default multi-line text box
-      markup: |
-        <textarea>Example entry</textarea>
-    - name: Focused multi-line text box
-      markup: |
-        <textarea class="focus">Example entry</textarea>
-    - name: Multi-line text box in error state
-      codenotes:
-        - 'role="alert"'
-      notes:
-        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
-      markup: |
-        <textarea class="error">Invalid input</textarea>
-        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
-    - name: Multi-line text box in success state
-      markup: |
-        <textarea class="success">Validated input</textarea>
-        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
-    tags:
-    - cf-forms
-*/
-input,
-textarea {
-  display: inline-block;
-  width: 85%;
-  margin: 0;
-  padding: 0.25em;
-  font-family: Arial, sans-serif;
-  font-size: 1em;
-  background: #ffffff;
-  border: 1px solid #75787b;
-  border-radius: 0;
-  vertical-align: top;
-  -webkit-appearance: none;
-  -webkit-user-modify: read-write-plaintext-only;
-}
-textarea {
-  overflow: auto;
-}
-input:focus,
-input.focus,
-textarea:focus,
-textarea.focus {
-  border: 1px solid #0072ce;
-  border-color: #0072ce;
-  outline: 1px solid #0072ce;
-  outline-offset: 0;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
-input.error,
-textarea.error {
-  border: 1px solid #d12124;
-  outline: 1px solid #d12124;
-}
-input.success,
-textarea.success {
-  border: 1px solid #2cb34a;
-  outline: 1px solid #2cb34a;
-}
-input + [class^="icon-"],
-textarea + [class^="icon-"] {
-  position: relative;
-  top: 0.15em;
-  margin-left: 0.2em;
-  font-size: 1.25em;
-}
-.error + [class^="icon-"] {
-  color: #d12124;
-}
-.success + [class^="icon-"] {
-  color: #2cb34a;
-}
-/* topdoc
-  name: EOF
-  eof: true
-*/
-/* ==========================================================================
-   Capital Framework
-   Color Variables
-   ========================================================================== */
-/* ==========================================================================
-   Capital Framework
-   Basic Typography
-   ========================================================================== */
-/* topdoc
-    name: LESS notes
-    family: cf-typography
-    patterns:
-    - name: Size variables
-      codenotes:
-        - "@base-font-size-px: 16px;"
-        - "@base-line-height-px: 22px;"
-        - "@base-line-height: unit(@base-line-height-px / @base-font-size-px);"
-    - name: Webfont mixins
-      codenotes:
-        - ".webfont-regular()"
-        - ".webfont-italic()"
-        - ".webfont-medium()"
-        - ".webfont-demi()"
-    - name: Explicitly set font styles
-      notes:
-        - "Any instances of Avenir Next getting italicized or bolded must be declared explicitly
-          so that it uses the correct webfont and does not fake the style on normal Avenir Next."
-        - "Use the webfont mixins above to make this easy. See the #blockquote styles as an example."
-      markup: |
-       <blockquote cite="http://cfpb.github.io/cf-typography/docs/index.html#webfont-notes">
-         Any instances of Avenir Next getting <em>italic</em><i>ized</i> or <strong>bold</strong><b>ed</b> must be declared explicitly ...
-       </blockquote> 
-    tags:
-    - cf-typography
-*/
-/* topdoc
-    name: Type hierarchy
-    family: cf-typography
-    patterns:
-    - name: Default body type
-      markup: |
-        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-    - name: Heading level 1
-      markup: |
-        <h1>Example heading element</h1>
-        <p class="h1">A non-heading element</p>
-    - name: Heading level 2
-      markup: |
-        <h2>Example heading element</h2>
-        <p class="h2">A non-heading element</p>
-    - name: Heading level 3
-      markup: |
-        <h3>Example heading element</h3>
-        <p class="h3">A non-heading element</p>
-    - name: Heading level 4
-      markup: |
-        <h4>Example heading element</h4>
-        <p class="h4">A non-heading element</p>
-    - name: Heading level 5
-      markup: |
-        <h5>Example heading element</h5>
-        <p class="h5">A non-heading element</p>
-    - name: Heading level 6
-      markup: |
-        <h6>Example heading element</h6>
-        <p class="h6">A non-heading element</p>
-    - name: Super header
-      markup: |
-        <h1 class="superheader">Example super heading</h1>
-        <p class="superheader">Example super heading</p>
-    tags:
-    - cf-typography
-*/
-body {
-  color: #101820;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 100%;
-  line-height: 1.375;
-}
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
-.h6 {
-  margin-top: 0;
-  font-family: "Avenir Next", Arial, sans-serif;
-  font-style: normal;
-  font-weight: normal;
-}
-h1,
-.h1 {
-  margin-bottom: 0.6470588235294118em;
-  font-size: 2.125em;
-  line-height: 1.2941176470588236;
-}
-h2,
-.h2 {
-  margin-bottom: 0.8461538461538461em;
-  font-size: 1.625em;
-  line-height: 1.2692307692307692;
-}
-h3,
-.h3 {
-  margin-bottom: 1em;
-  font-size: 1.375em;
-  line-height: 1.2727272727272727;
-}
-h4,
-.h4 {
-  font-family: "Avenir Next Medium", Arial, sans-serif;
-  font-style: normal;
-  font-weight: 500;
-  margin-bottom: 1.2222222222222223em;
-  font-size: 1.125em;
-  line-height: 1.2222222222222223;
-}
-h5,
-h6,
-.h5,
-.h6 {
-  font-family: "Avenir Next Demi", Arial, sans-serif;
-  font-style: normal;
-  font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-}
-h5,
-.h5 {
-  margin-bottom: 1.5714285714285714em;
-  font-size: 0.875em;
-  line-height: 1.5714285714285714;
-}
-h6,
-.h6 {
-  margin-bottom: 1.8333333333333333em;
-  font-size: 0.75em;
-  line-height: 1.8333333333333333;
-}
-.superheader {
-  font-family: "Avenir Next Demi", Arial, sans-serif;
-  font-style: normal;
-  font-weight: bold;
-  margin-bottom: 0.4583333333333333em;
-  font-size: 3em;
-  line-height: 1.375;
-}
-/* topdoc
-    name: Margins
-    family: cf-typography
-    patterns:
-    - name: Consistent vertical margins
-      notes:
-        - "Assumes that the font size of each of these items remains the default."
-      markup: |
-        <p>Paragraph margin example</p>
-        <p>Paragraph margin example</p>
-    tags:
-    - cf-typography
-*/
-p,
-ul,
-ol,
-dl,
-table,
-blockquote,
-figure {
-  margin-top: 0;
-  margin-bottom: 1.375em;
-}
-/* topdoc
-    name: Default link
-    notes:
-      - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not 
-        be used in production."
-    family: cf-typography
-    patterns:
-    - name: Default state
-      markup: |
-        <a href="#">Default link style</a>
-    - name: Visited state
-      markup: |
-        <a href="#" class="visited">Visited link style</a>
-    - name: Hovered state
-      markup: |
-        <a href="#" class="hover">Hovered link style</a>
-    - name: Focused state
-      markup: |
-        <a href="#" class="focus">Focused link style</a>
-    - name: Active state
-      markup: |
-        <a href="#" class="active">Active link style</a>
-    tags:
-    - cf-typography
-*/
-a {
-  border-bottom-width: 0;
-  border-bottom-style: dotted;
-  border-bottom-color: #0072ce;
-  color: #0072ce;
-  text-decoration: none;
-}
-a:visited,
-a.visited {
-  border-bottom-color: #005e5d;
-  color: #005e5d;
-}
-a:hover,
-a.hover {
-  border-bottom-style: solid;
-  border-bottom-color: #7fb8e6;
-  color: #7fb8e6;
-}
-a:focus,
-a.focus {
-  border-bottom-style: solid;
-}
-a:active,
-a.active {
-  border-bottom-style: solid;
-  border-bottom-color: #002d72;
-  color: #002d72;
-}
-/* topdoc
-    name: Underlined links
-    family: cf-typography
-    patterns:
-    - name: States
-      notes:
-        - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not 
-          be used in production."
-        - "The underline style properties are mostly set above in the a tag.
-          To enable the underline simply set a bottom-border-width as done here."
-      markup: |
-        <p>
-            <a href="#">Default</a>,
-            <a href="#" class="visited">Visited</a>,
-            <a href="#" class="hover">Hovered</a>,
-            <a href="#" class="focus">Focused</a>,
-            <a href="#" class="active">Active</a>
-        </p>
-    - name: Underline conditions
-      notes:
-       - "We're restricting link borders to links within p, li, and dd so that
-         we don't have to override them every time we want a plain link."
-      markup: |
-        <p>
-            <a href="#">A child of a paragraph</a>
-        </p>
-        <ul>
-            <li>
-                <a href="#">A child of a list item</a>
-            </li>
-        </ul>
-        <dl>
-            <dt>
-                Definition list term
-            </dt>
-            <dd>
-                <a href="#">A child of a definition list description</a>
-            </dd>
-        </dl>
-    - name: Exceptions for underlined links
-      notes:
-        - "Inline text links inside of a nav element are not underlined."
-      markup: |
-        <nav>
-            <p>
-                <a href="#">A child of a paragraph</a>
-            </p>
-            <ul>
-                <li>
-                    <a href="#">A child of a list item</a>
-                </li>
-            </ul>
-            <dl>
-                <dt>
-                    Definition list term
-                </dt>
-                <dd>
-                    <a href="#">A child of a definition list description</a>
-                </dd>
-            </dl>
-        </nav>
-    tags:
-    - cf-typography
-*/
-p a,
-li a,
-dd a {
-  border-bottom-width: 1px;
-}
-nav a {
-  border-bottom-width: 0;
-}
-/* topdoc
-    name: Blockquote
-    family: cf-typography
-    patterns:
-    - name: Default blockquote
-      markup: |
-       <blockquote>
-         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi animi facere modi eaque amet odio!
-       </blockquote> 
-    tags:
-    - cf-typography
-*/
-blockquote {
-  padding: 0.5em 0.75em;
-  border-left: 4px solid #2cb34a;
-  background: #addc91;
-  font-family: "Avenir Next", Arial, sans-serif;
-  font-style: normal;
-  font-weight: normal;
-}
-blockquote em,
-blockquote i {
-  font-family: "Avenir Next Italic", Arial, sans-serif;
-  font-style: italic;
-  font-weight: normal;
-}
-blockquote strong,
-blockquote b {
-  font-family: "Avenir Next Demi", Arial, sans-serif;
-  font-style: normal;
-  font-weight: bold;
-}
-/* topdoc
-    name: Lists
-    family: cf-typography
-    patterns:
-    - name: Unordered list
-      markup: |
-       <ul>
-         <li>List item</li>
-         <li>List item</li>
-         <li>List item</li>
-       </ul>
-    tags:
-    - cf-typography
-*/
-ul {
-  list-style: square;
-}
-/* topdoc
-    name: IE overrides
-    family: cf-typography
-    patterns:
-    - name: Prevent faux/double bold and italics in IE 6-8
-      notes:
-        - "Any bold or italic Avenir elements added to the base styles MUST BE added to this section, as well."
-        - "Dependent on using H5BP's conditional classes on the <html> element:
-          https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md"
-      markup: |
-        <h5>I might appear as faux/double bold in older IE without this fix.</h5>
-    tags:
-    - cf-typography
-    - ltie9
-*/
-.lt-ie9 h1,
-.lt-ie9 h2,
-.lt-ie9 h3,
-.lt-ie9 h4,
-.lt-ie9 h5,
-.lt-ie9 h6,
-.lt-ie9 blockquote strong {
-  font-weight: normal !important;
-}
-.lt-ie9 blockquote em {
-  font-style: normal !important;
-}
-/* topdoc
-  name: EOF
-  eof: true
-*/
 /*!
  *  Font Awesome 3.2.1
  *  the iconic font designed for Bootstrap
@@ -567,7 +80,7 @@ a [class*=" icon-"] {
 }
 .icons-ul .icon-li {
   position: absolute;
-  left: -2.142857142857143em;
+  left: -2.14285714em;
   width: 2.142857142857143em;
   text-align: center;
   line-height: inherit;
@@ -782,12 +295,10 @@ a .icon-spin {
 @keyframes spin {
   0% {
     -webkit-transform: rotate(0deg);
-    -ms-transform: rotate(0deg);
     transform: rotate(0deg);
   }
   100% {
     -webkit-transform: rotate(359deg);
-    -ms-transform: rotate(359deg);
     transform: rotate(359deg);
   }
 }
@@ -1930,3 +1441,491 @@ a .icon-flip-vertical:before {
 .icon-renren:before {
   content: "\f18b";
 }
+
+/* ==========================================================================
+   Capital Framework
+   Form Element Styling
+   ========================================================================== */
+label {
+  display: block;
+}
+/* topdoc
+    name: Single/Multi-Line Text Inputs
+    family: cf-forms
+    patterns:
+    - name: Default single-line text input
+      markup: |
+        <input placeholder="placeholder text" type="text">
+    - name: Focused single-line text input
+      markup: |
+        <input class="focus" placeholder="placeholder text" type="text">
+    - name: Field in error state
+      codenotes:
+        - 'role="alert"'
+      notes:
+        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+      markup: |
+        <input class="error" type="text" value="Invalid input">
+        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
+    - name: Field in success state
+      markup: |
+        <input class="success" type="text" value="Validated input">
+        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
+    - name: Default multi-line text box
+      markup: |
+        <textarea>Example entry</textarea>
+    - name: Focused multi-line text box
+      markup: |
+        <textarea class="focus">Example entry</textarea>
+    - name: Multi-line text box in error state
+      codenotes:
+        - 'role="alert"'
+      notes:
+        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+      markup: |
+        <textarea class="error">Invalid input</textarea>
+        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
+    - name: Multi-line text box in success state
+      markup: |
+        <textarea class="success">Validated input</textarea>
+        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
+    tags:
+    - cf-forms
+*/
+input,
+textarea {
+  display: inline-block;
+  width: 85%;
+  margin: 0;
+  padding: 0.25em;
+  font-family: Arial, sans-serif;
+  font-size: 1em;
+  background: #ffffff;
+  border: 1px solid #75787b;
+  border-radius: 0;
+  vertical-align: top;
+  -webkit-appearance: none;
+  -webkit-user-modify: read-write-plaintext-only;
+}
+textarea {
+  overflow: auto;
+}
+input:focus,
+input.focus,
+textarea:focus,
+textarea.focus {
+  border: 1px solid #0072ce;
+  border-color: #0072ce;
+  outline: 1px solid #0072ce;
+  outline-offset: 0;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+input.error,
+textarea.error {
+  border: 1px solid #d12124;
+  outline: 1px solid #d12124;
+}
+input.success,
+textarea.success {
+  border: 1px solid #2cb34a;
+  outline: 1px solid #2cb34a;
+}
+input + [class^="icon-"],
+textarea + [class^="icon-"] {
+  position: relative;
+  top: 0.15em;
+  margin-left: 0.2em;
+  font-size: 1.25em;
+}
+.error + [class^="icon-"] {
+  color: #d12124;
+}
+.success + [class^="icon-"] {
+  color: #2cb34a;
+}
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Color Variables
+   ========================================================================== */
+/* ==========================================================================
+   Capital Framework
+   Basic Typography
+   ========================================================================== */
+/* topdoc
+    name: LESS notes
+    family: cf-typography
+    patterns:
+    - name: Size variables
+      codenotes:
+        - "@base-font-size-px: 16px;"
+        - "@base-line-height-px: 22px;"
+        - "@base-line-height: unit(@base-line-height-px / @base-font-size-px);"
+    - name: Webfont mixins
+      codenotes:
+        - ".webfont-regular()"
+        - ".webfont-italic()"
+        - ".webfont-medium()"
+        - ".webfont-demi()"
+    - name: Explicitly set font styles
+      notes:
+        - "Any instances of Avenir Next getting italicized or bolded must be declared explicitly
+          so that it uses the correct webfont and does not fake the style on normal Avenir Next."
+        - "Use the webfont mixins above to make this easy. See the #blockquote styles as an example."
+      markup: |
+       <blockquote cite="http://cfpb.github.io/cf-typography/docs/index.html#webfont-notes">
+         Any instances of Avenir Next getting <em>italic</em><i>ized</i> or <strong>bold</strong><b>ed</b> must be declared explicitly ...
+       </blockquote> 
+    tags:
+    - cf-typography
+*/
+/* topdoc
+    name: Type hierarchy
+    family: cf-typography
+    patterns:
+    - name: Default body type
+      markup: |
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    - name: Heading level 1
+      markup: |
+        <h1>Example heading element</h1>
+        <p class="h1">A non-heading element</p>
+    - name: Heading level 2
+      markup: |
+        <h2>Example heading element</h2>
+        <p class="h2">A non-heading element</p>
+    - name: Heading level 3
+      markup: |
+        <h3>Example heading element</h3>
+        <p class="h3">A non-heading element</p>
+    - name: Heading level 4
+      markup: |
+        <h4>Example heading element</h4>
+        <p class="h4">A non-heading element</p>
+    - name: Heading level 5
+      markup: |
+        <h5>Example heading element</h5>
+        <p class="h5">A non-heading element</p>
+    - name: Heading level 6
+      markup: |
+        <h6>Example heading element</h6>
+        <p class="h6">A non-heading element</p>
+    - name: Super header
+      markup: |
+        <h1 class="superheader">Example super heading</h1>
+        <p class="superheader">Example super heading</p>
+    tags:
+    - cf-typography
+*/
+body {
+  color: #101820;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 100%;
+  line-height: 1.375;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  margin-top: 0;
+  font-family: "Avenir Next", Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+h1,
+.h1 {
+  margin-bottom: 0.64705882em;
+  font-size: 2.125em;
+  line-height: 1.29411765;
+}
+h2,
+.h2 {
+  margin-bottom: 0.84615385em;
+  font-size: 1.625em;
+  line-height: 1.26923077;
+}
+h3,
+.h3 {
+  margin-bottom: 1em;
+  font-size: 1.375em;
+  line-height: 1.27272727;
+}
+h4,
+.h4 {
+  font-family: "Avenir Next Medium", Arial, sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  margin-bottom: 1.22222222em;
+  font-size: 1.125em;
+  line-height: 1.22222222;
+}
+h5,
+h6,
+.h5,
+.h6 {
+  font-family: "Avenir Next Demi", Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+h5,
+.h5 {
+  margin-bottom: 1.57142857em;
+  font-size: 0.875em;
+  line-height: 1.57142857;
+}
+h6,
+.h6 {
+  margin-bottom: 1.83333333em;
+  font-size: 0.75em;
+  line-height: 1.83333333;
+}
+.superheader {
+  font-family: "Avenir Next Demi", Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 0.45833333em;
+  font-size: 3em;
+  line-height: 1.375;
+}
+/* topdoc
+    name: Margins
+    family: cf-typography
+    patterns:
+    - name: Consistent vertical margins
+      notes:
+        - "Assumes that the font size of each of these items remains the default."
+      markup: |
+        <p>Paragraph margin example</p>
+        <p>Paragraph margin example</p>
+    tags:
+    - cf-typography
+*/
+p,
+ul,
+ol,
+dl,
+table,
+blockquote,
+figure {
+  margin-top: 0;
+  margin-bottom: 1.375em;
+}
+/* topdoc
+    name: Default link
+    notes:
+      - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not 
+        be used in production."
+    family: cf-typography
+    patterns:
+    - name: Default state
+      markup: |
+        <a href="#">Default link style</a>
+    - name: Visited state
+      markup: |
+        <a href="#" class="visited">Visited link style</a>
+    - name: Hovered state
+      markup: |
+        <a href="#" class="hover">Hovered link style</a>
+    - name: Focused state
+      markup: |
+        <a href="#" class="focus">Focused link style</a>
+    - name: Active state
+      markup: |
+        <a href="#" class="active">Active link style</a>
+    tags:
+    - cf-typography
+*/
+a {
+  border-bottom-width: 0;
+  border-bottom-style: dotted;
+  border-bottom-color: #0072ce;
+  color: #0072ce;
+  text-decoration: none;
+}
+a:visited,
+a.visited {
+  border-bottom-color: #005e5d;
+  color: #005e5d;
+}
+a:hover,
+a.hover {
+  border-bottom-style: solid;
+  border-bottom-color: #7fb8e6;
+  color: #7fb8e6;
+}
+a:focus,
+a.focus {
+  border-bottom-style: solid;
+}
+a:active,
+a.active {
+  border-bottom-style: solid;
+  border-bottom-color: #002d72;
+  color: #002d72;
+}
+/* topdoc
+    name: Underlined links
+    family: cf-typography
+    patterns:
+    - name: States
+      notes:
+        - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not 
+          be used in production."
+        - "The underline style properties are mostly set above in the a tag.
+          To enable the underline simply set a bottom-border-width as done here."
+      markup: |
+        <p>
+            <a href="#">Default</a>,
+            <a href="#" class="visited">Visited</a>,
+            <a href="#" class="hover">Hovered</a>,
+            <a href="#" class="focus">Focused</a>,
+            <a href="#" class="active">Active</a>
+        </p>
+    - name: Underline conditions
+      notes:
+       - "We're restricting link borders to links within p, li, and dd so that
+         we don't have to override them every time we want a plain link."
+      markup: |
+        <p>
+            <a href="#">A child of a paragraph</a>
+        </p>
+        <ul>
+            <li>
+                <a href="#">A child of a list item</a>
+            </li>
+        </ul>
+        <dl>
+            <dt>
+                Definition list term
+            </dt>
+            <dd>
+                <a href="#">A child of a definition list description</a>
+            </dd>
+        </dl>
+    - name: Exceptions for underlined links
+      notes:
+        - "Inline text links inside of a nav element are not underlined."
+      markup: |
+        <nav>
+            <p>
+                <a href="#">A child of a paragraph</a>
+            </p>
+            <ul>
+                <li>
+                    <a href="#">A child of a list item</a>
+                </li>
+            </ul>
+            <dl>
+                <dt>
+                    Definition list term
+                </dt>
+                <dd>
+                    <a href="#">A child of a definition list description</a>
+                </dd>
+            </dl>
+        </nav>
+    tags:
+    - cf-typography
+*/
+p a,
+li a,
+dd a {
+  border-bottom-width: 1px;
+}
+nav a {
+  border-bottom-width: 0;
+}
+/* topdoc
+    name: Blockquote
+    family: cf-typography
+    patterns:
+    - name: Default blockquote
+      markup: |
+       <blockquote>
+         Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi animi facere modi eaque amet odio!
+       </blockquote> 
+    tags:
+    - cf-typography
+*/
+blockquote {
+  padding: 0.5em 0.75em;
+  border-left: 4px solid #2cb34a;
+  background: #addc91;
+  font-family: "Avenir Next", Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+blockquote em,
+blockquote i {
+  font-family: "Avenir Next Italic", Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+blockquote strong,
+blockquote b {
+  font-family: "Avenir Next Demi", Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+/* topdoc
+    name: Lists
+    family: cf-typography
+    patterns:
+    - name: Unordered list
+      markup: |
+       <ul>
+         <li>List item</li>
+         <li>List item</li>
+         <li>List item</li>
+       </ul>
+    tags:
+    - cf-typography
+*/
+ul {
+  list-style: square;
+}
+/* topdoc
+    name: IE overrides
+    family: cf-typography
+    patterns:
+    - name: Prevent faux/double bold and italics in IE 6-8
+      notes:
+        - "Any bold or italic Avenir elements added to the base styles MUST BE added to this section, as well."
+        - "Dependent on using H5BP's conditional classes on the <html> element:
+          https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md"
+      markup: |
+        <h5>I might appear as faux/double bold in older IE without this fix.</h5>
+    tags:
+    - cf-typography
+    - ltie9
+*/
+.lt-ie9 h1,
+.lt-ie9 h2,
+.lt-ie9 h3,
+.lt-ie9 h4,
+.lt-ie9 h5,
+.lt-ie9 h6,
+.lt-ie9 blockquote strong {
+  font-weight: normal !important;
+}
+.lt-ie9 blockquote em {
+  font-style: normal !important;
+}
+/* topdoc
+  name: EOF
+  eof: true
+*/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "cf-forms",
   "version": "0.4.0",
   "description": "Standard form input/textarea elements for Capital Framework.",
-  "keywords": ["capital-framework", "capital", "forms", "less"],
+  "keywords": [
+    "capital-framework",
+    "capital",
+    "forms",
+    "less"
+  ],
   "author": {
     "name": "Consumer Financial Protection Bureau",
     "url": "http://cfpb.github.io/"
@@ -24,15 +29,12 @@
     "node": ">=0.8.0"
   },
   "devDependencies": {
+    "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git",
+    "cf-grunt-config": "git://github.com/cfpb/cf-grunt-config.git",
+    "glob": "~3.2.9",
     "grunt": "latest",
-    "grunt-autoprefixer": "latest",
-    "grunt-bower-task": "~0.3.2",
-    "grunt-contrib-clean": "latest",
-    "grunt-contrib-concat": "latest",
-    "grunt-contrib-copy": "latest",
-    "grunt-contrib-less": "~0.8.3",
-    "grunt-string-replace": "latest",
-    "grunt-topdoc": "~0.2.0",
-    "cf-component-demo": "git://github.com/cfpb/cf-component-demo.git"
+    "jit-grunt": "latest",
+    "load-grunt-tasks": "latest",
+    "time-grunt": "latest"
   }
 }


### PR DESCRIPTION
- Adds cf-grunt-config to `package.json`.
- Replaced `Gruntfile.js` with the one from cf-typography to take advantage of cf-grunt-config.
- Re-runs `grunt vendor` and `grunt` to recompile CSS and rebuild `docs/` and `demo/`.
