### PR TITLE
Fixes #1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-forms",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Standard form input/textarea elements for Capital Framework.",
   "keywords": ["capital-framework", "capital", "forms", "less"],
   "authors": [

--- a/demo/custom.html
+++ b/demo/custom.html
@@ -1,5 +1,12 @@
 
 <!--
-<hr><br>
 Add custom demo HTML here
 -->
+
+<!--
+Since we have only style text-based input let's do a quick check ot make sure
+that other form input types are not affected.
+-->
+<hr><br>
+<input type="checkbox">
+<input type="radio">

--- a/demo/index.html
+++ b/demo/index.html
@@ -244,9 +244,16 @@
     </div>
     <div id="custom-demo">
 <!--
-<hr><br>
 Add custom demo HTML here
 -->
+
+<!--
+Since we have only style text-based input let's do a quick check ot make sure
+that other form input types are not affected.
+-->
+<hr><br>
+<input type="checkbox">
+<input type="radio">
 </div>
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,29 +14,182 @@
     <link rel="stylesheet" type="text/css" href="static/css/main.css">
   </head>
   <body style="padding:4px;">
-    <div id="singlemulti-line-text-inputs">
+    <div id="form-labels">
       <div>
         <div>
-<input placeholder="placeholder text" type="text">
+<label>I am a form label</label>
+</div><br>
+      </div>
+    </div>
+    <div id="single-line-text-input">
+      <div>
+        <div>
+<input placeholder="placeholder text" type="text" value="">
 </div><br>
       </div>
       <div>
         <div>
-<input class="focus" placeholder="placeholder text" type="text">
+<input class="focus" placeholder="placeholder text" type="text" value="">
 </div><br>
       </div>
       <div>
         <div>
-<input class="error" type="text" value="Invalid input">
-<i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
+<input class="error" placeholder="placeholder text" type="text" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
 </div><br>
       </div>
       <div>
         <div>
-<input class="success" type="text" value="Validated input">
-<i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
+<input class="success" placeholder="placeholder text" type="text" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
 </div><br>
       </div>
+    </div>
+    <div id="single-line-search-input">
+      <div>
+        <div>
+<input placeholder="placeholder search text" type="search" value="">
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="focus" placeholder="placeholder search text" type="search" value="">
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="error" placeholder="placeholder search text" type="search" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="success" placeholder="placeholder search text" type="search" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+    </div>
+    <div id="single-line-email-input">
+      <div>
+        <div>
+<input placeholder="placeholder email text" type="email" value="">
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="focus" placeholder="placeholder email text" type="email" value="">
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="error" placeholder="placeholder email text" type="email" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="success" placeholder="placeholder email text" type="email" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+    </div>
+    <div id="single-line-url-input">
+      <div>
+        <div>
+<input placeholder="placeholder url text" type="url" value="">
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="focus" placeholder="placeholder url text" type="url" value="">
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="error" placeholder="placeholder url text" type="url" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="success" placeholder="placeholder url text" type="url" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+    </div>
+    <div id="single-line-tel-input">
+      <div>
+        <div>
+<input placeholder="placeholder tel text" type="tel" value="">
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="focus" placeholder="placeholder tel text" type="tel" value="">
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="error" placeholder="placeholder tel text" type="tel" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="success" placeholder="placeholder tel text" type="tel" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+    </div>
+    <div id="single-line-number-input">
+      <div>
+        <div>
+<input placeholder="placeholder number text" type="number" value="">
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="focus" placeholder="placeholder number text" type="number" value="">
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="error" placeholder="placeholder number text" type="number" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="success" placeholder="placeholder number text" type="number" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+    </div>
+    <div id="multiline-textarea">
       <div>
         <div>
 <textarea>Example entry</textarea>
@@ -50,13 +203,42 @@
       <div>
         <div>
 <textarea class="error">Invalid input</textarea>
-<i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
+<i class="cf-form_input-icon icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
 </div><br>
       </div>
       <div>
         <div>
 <textarea class="success">Validated input</textarea>
-<i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
+<i class="cf-form_input-icon icon-ok-sign"><span class="jekyll-bug"></span></i>
+</div><br>
+      </div>
+    </div>
+    <div id="form-icons">
+      <div>
+        <div></div><br>
+      </div>
+      <div>
+        <div>
+<input type="text" value="">
+<i class="cf-form_input-icon icon-credit-card">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="error" placeholder="placeholder search text" type="search" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</div><br>
+      </div>
+      <div>
+        <div>
+<input class="success" placeholder="placeholder search text" type="search" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
 </div><br>
       </div>
     </div>

--- a/demo/static/css/main.css
+++ b/demo/static/css/main.css
@@ -2005,53 +2005,58 @@ a .icon-flip-vertical:before {
    Capital Framework
    Form Element Styling
    ========================================================================== */
+/* topdoc
+    name: Form labels
+    family: cf-forms
+    patterns:
+    - name: Default label
+      notes:
+        - "Warning, this pattern is still under development."
+      markup: |
+        <label>I am a form label</label>
+    tags:
+    - cf-forms
+*/
 label {
   display: block;
 }
 /* topdoc
-    name: Single/Multi-Line Text Inputs
+    name: Single-line text input
+    notes:
+      - Most other text-based inputs extend styles from here as seen in the CSS to the right.
     family: cf-forms
     patterns:
     - name: Default single-line text input
       markup: |
-        <input placeholder="placeholder text" type="text">
-    - name: Focused single-line text input
+        <input placeholder="placeholder text" type="text" value="">
+    - name: Focused state
       markup: |
-        <input class="focus" placeholder="placeholder text" type="text">
-    - name: Field in error state
-      codenotes:
-        - 'role="alert"'
+        <input class="focus" placeholder="placeholder text" type="text" value="">
+    - name: Error state
       notes:
-        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+        - Please review the notes on form input error icons in the form icons section below.
       markup: |
-        <input class="error" type="text" value="Invalid input">
-        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
-    - name: Field in success state
-      markup: |
-        <input class="success" type="text" value="Validated input">
-        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
-    - name: Default multi-line text box
-      markup: |
-        <textarea>Example entry</textarea>
-    - name: Focused multi-line text box
-      markup: |
-        <textarea class="focus">Example entry</textarea>
-    - name: Multi-line text box in error state
-      codenotes:
-        - 'role="alert"'
+        <input class="error" placeholder="placeholder text" type="text" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
       notes:
-        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+        - Please review the notes on form input success icons in the form icons section below.
       markup: |
-        <textarea class="error">Invalid input</textarea>
-        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
-    - name: Multi-line text box in success state
-      markup: |
-        <textarea class="success">Validated input</textarea>
-        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
+        <input class="success" placeholder="placeholder text" type="text" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
     tags:
     - cf-forms
 */
-input,
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="url"],
+input[type="tel"],
+input[type="number"],
 textarea {
   display: inline-block;
   width: 85%;
@@ -2066,11 +2071,18 @@ textarea {
   -webkit-appearance: none;
   -webkit-user-modify: read-write-plaintext-only;
 }
-textarea {
-  overflow: auto;
-}
-input:focus,
-input.focus,
+input[type="text"]:focus,
+input[type="text"].focus,
+input[type="search"]:focus,
+input[type="search"].focus,
+input[type="email"]:focus,
+input[type="email"].focus,
+input[type="url"]:focus,
+input[type="url"].focus,
+input[type="tel"]:focus,
+input[type="tel"].focus,
+input[type="number"]:focus,
+input[type="number"].focus,
 textarea:focus,
 textarea.focus {
   border: 1px solid #0072ce;
@@ -2080,27 +2092,262 @@ textarea.focus {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-input.error,
+input[type="text"].error,
+input[type="search"].error,
+input[type="email"].error,
+input[type="url"].error,
+input[type="tel"].error,
+input[type="number"].error,
 textarea.error {
   border: 1px solid #d12124;
   outline: 1px solid #d12124;
 }
-input.success,
+input[type="text"].success,
+input[type="search"].success,
+input[type="email"].success,
+input[type="url"].success,
+input[type="tel"].success,
+input[type="number"].success,
 textarea.success {
   border: 1px solid #2cb34a;
   outline: 1px solid #2cb34a;
 }
-input + [class^="icon-"],
-textarea + [class^="icon-"] {
+/* topdoc
+    name: Single-line search input
+    family: cf-forms
+    patterns:
+    - name: Default single-line search input
+      markup: |
+        <input placeholder="placeholder search text" type="search" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder search text" type="search" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder search text" type="search" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder search text" type="search" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all input[type="search"] styles extend input[type="text"]. */
+/* topdoc
+    name: Single-line email input
+    family: cf-forms
+    patterns:
+    - name: Default single-line email input
+      markup: |
+        <input placeholder="placeholder email text" type="email" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder email text" type="email" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder email text" type="email" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder email text" type="email" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all input[type="email"] styles extend input[type="text"]. */
+/* topdoc
+    name: Single-line url input
+    family: cf-forms
+    patterns:
+    - name: Default single-line url input
+      markup: |
+        <input placeholder="placeholder url text" type="url" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder url text" type="url" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder url text" type="url" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder url text" type="url" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all input[type="url"] styles extend input[type="text"]. */
+/* topdoc
+    name: Single-line tel input
+    family: cf-forms
+    patterns:
+    - name: Default single-line tel input
+      markup: |
+        <input placeholder="placeholder tel text" type="tel" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder tel text" type="tel" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder tel text" type="tel" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder tel text" type="tel" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all input[type="tel"] styles extend input[type="text"]. */
+/* topdoc
+    name: Single-line number input
+    family: cf-forms
+    patterns:
+    - name: Default single-line number input
+      markup: |
+        <input placeholder="placeholder number text" type="number" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder number text" type="number" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder number text" type="number" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder number text" type="number" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all input[type="number"] styles extend input[type="text"]. */
+/* topdoc
+    name: Multiline textarea
+    family: cf-forms
+    patterns:
+    - name: Default multi-line text box
+      markup: |
+        <textarea>Example entry</textarea>
+    - name: Focused multi-line text box
+      markup: |
+        <textarea class="focus">Example entry</textarea>
+    - name: Multi-line text box in error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <textarea class="error">Invalid input</textarea>
+        <i class="cf-form_input-icon icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
+    - name: Multi-line text box in success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <textarea class="success">Validated input</textarea>
+        <i class="cf-form_input-icon icon-ok-sign"><span class="jekyll-bug"></span></i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all textarea styles extend input[type="text"]. */
+textarea {
+  overflow: auto;
+}
+/* topdoc
+    name: Form icons
+    family: cf-forms
+    patterns:
+    - name: The .jekyll-bug element
+      codenotes:
+        - |
+          <i class="cf-form_input-icon icon-credit-card">
+            <span class="jekyll-bug"></span>
+          </i>
+      notes:
+        - |
+          Adding the .jekyll-bug element inside of an icon is only necessary
+          when using Jekyll as it tends to ignore empty <i> elements.
+    - name: Form input icons
+      notes:
+        - "Form input icons add small positioning tweaks to Font Awesome icons."
+        - "They are meant to be positioned after a form input."
+      markup: |
+        <input type="text" value="">
+        <i class="cf-form_input-icon icon-credit-card">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Form input error icon
+      notes:
+        - |
+          The icon must be placed directly after the form input in the markup
+          and the input must have the class of "error".
+        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+      markup: |
+        <input class="error" placeholder="placeholder search text" type="search" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Form input success icon
+      notes:
+        - |
+          The icon must be placed directly after the form input in the markup
+          and the input must have the class of "success".
+      markup: |
+        <input class="success" placeholder="placeholder search text" type="search" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+.cf-form_input-icon {
   position: relative;
   top: 0.15em;
   margin-left: 0.2em;
   font-size: 1.25em;
 }
-.error + [class^="icon-"] {
+.error + .cf-form_input-icon {
   color: #d12124;
 }
-.success + [class^="icon-"] {
+.success + .cf-form_input-icon {
   color: #2cb34a;
 }
 /* topdoc
@@ -2488,4 +2735,4 @@ ul {
   name: EOF
   eof: true
 */
-/*# sourceMappingURL=data:application/json,%7B%22version%22%3A3%2C%22sources%22%3A%5B%22src%2Fvendor%2Fcf-concat%2Fcf.less%22%5D%2C%22names%22%3A%5B%5D%2C%22mappings%22%3A%22%3B%3B%3B%3BAAKA%3BEACI%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA%2BCJ%3BAACA%3BEAGI%2CqBAAA%3BEACA%2CUAAA%3BEACA%2CSAAA%3BEACA%2CeAAA%3BEACA%2C8BAAA%3BEACA%2CcAAA%3BEACA%2CmBAAA%3BEACA%2CyBAAA%3BEACA%2CwBAAA%3BEACG%2CqBAAA%3BEACK%2CgBAAA%3BEACR%2CmBAAA%3BEACA%2CwBAAA%3BEACA%2C8CAAA%3B%3BAAGJ%3BEACE%2CcAAA%3B%3BAAGF%2CKAAK%3BAACL%2CKAAK%3BAACL%2CQAAQ%3BAACR%2CQAAQ%3BEAEJ%2CyBAAA%3BEACA%2CqBAAA%3BEACA%2C0BAAA%3BEACA%2CiBAAA%3BEACA%2CwBAAA%3BEACQ%2CgBAAA%3B%3BAAGZ%2CKAAK%3BAACL%2CQAAQ%3BEACJ%2CyBAAA%3BEACA%2C0BAAA%3B%3BAAGJ%2CKAAK%3BAACL%2CQAAQ%3BEACJ%2CyBAAA%3BEACA%2C0BAAA%3B%3BAAGJ%2CKAAM%3BAACN%2CQAAS%3BEAGL%2CkBAAA%3BEACA%2CWAAA%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3B%3BAAGJ%2CMAAO%3BEACH%2CcAAA%3B%3BAAGJ%2CQAAS%3BEACL%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA6IJ%3BEACI%2CcAAA%3BEACA%2CsBAAsB%2CwBAAtB%3BEACA%2CeAAA%3BEACA%2CkBAAA%3B%3BAAGJ%3BAAAI%3BAAAI%3BAAAI%3BAAAI%3BAAAI%3BAACpB%3BAAAK%3BAAAK%3BAAAK%3BAAAK%3BAAAK%3BEACrB%2CaAAA%3BEAxEA%2CaAAa%2CgCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAA0EJ%3BAACA%3BEAII%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAII%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAII%2CkBAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEA%2FFI%2CaAAa%2CuCAAb%3BEACA%2CkBAAA%3BEACA%2CgBAAA%3BEAiGA%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BAACA%3BAACA%3BEArGI%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3BEAsGA%2CmBAAA%3BEACA%2CyBAAA%3B%3BAAGJ%3BAACA%3BEAGI%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAGI%2C2BAAA%3BEACA%2CiBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BEA9HI%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3BEAmIA%2C2BAAA%3BEACA%2CcAAA%3BEACA%2CkBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAkBJ%3BAACA%3BAACA%3BAACA%3BAACA%3BAACA%3BAACA%3BEACI%2CaAAA%3BEACA%2CsBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA8BJ%3BEACI%2CsBAAA%3BEACA%2C2BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3BEACA%2CqBAAA%3B%3BAAEA%2CCAAC%3BAACD%2CCAAC%3BEACG%2C4BAAA%3BEACA%2CcAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAsER%2CCAKI%3BAAJJ%2CEAII%3BAAHJ%2CEAGI%3BEACI%2CwBAAA%3B%3BAAIR%2CGAAI%3BEAEA%2CsBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAiBJ%3BEACI%2CqBAAA%3BEACA%2C8BAAA%3BEACA%2CmBAAA%3BEApVA%2CaAAa%2CgCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAAqVA%2CUAAE%3BAACF%2CUAAE%3BEAlVF%2CaAAa%2CuCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAAoVA%2CUAAE%3BAACF%2CUAAE%3BEA3UF%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA8VJ%3BEACI%2CkBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAoBJ%2COACI%3BAADJ%2COACQ%3BAADR%2COACY%3BAADZ%2COACgB%3BAADhB%2COACoB%3BAADpB%2COACwB%3BAADxB%2COAEI%2CWAAW%3BEACP%2C8BAAA%3B%3BAAHR%2COAMI%2CWAAW%3BEACP%2C6BAAA%22%7D */
+/*# sourceMappingURL=data:application/json,%7B%22version%22%3A3%2C%22sources%22%3A%5B%22src%2Fvendor%2Fcf-concat%2Fcf.less%22%5D%2C%22names%22%3A%5B%5D%2C%22mappings%22%3A%22%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAmBA%3BEACI%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAoCJ%2CKAAK%3BAAyEL%2CKAAK%3BAAmDL%2CKAAK%3BAAmDL%2CKAAK%3BAAmDL%2CKAAK%3BAAmDL%2CKAAK%3BAA%2BCL%3BEAjUI%2CqBAAA%3BEACA%2CUAAA%3BEACA%2CSAAA%3BEACA%2CeAAA%3BEACA%2C8BAAA%3BEACA%2CcAAA%3BEACA%2CmBAAA%3BEACA%2CyBAAA%3BEACA%2CwBAAA%3BEACG%2CqBAAA%3BEACK%2CgBAAA%3BEACR%2CmBAAA%3BEACA%2CwBAAA%3BEACA%2C8CAAA%3B%3BAAGJ%2CKAAK%2CaAAa%3BAAClB%2CKAAK%2CaAAa%3BAAyDlB%2CKAAK%2CeAAe%3BAACpB%2CKAAK%2CeAAe%3BAAkDpB%2CKAAK%2CcAAc%3BAACnB%2CKAAK%2CcAAc%3BAAkDnB%2CKAAK%2CYAAY%3BAACjB%2CKAAK%2CYAAY%3BAAkDjB%2CKAAK%2CYAAY%3BAACjB%2CKAAK%2CYAAY%3BAAkDjB%2CKAAK%2CeAAe%3BAACpB%2CKAAK%2CeAAe%3BAA%2BCpB%2CQAAQ%3BAACR%2CQAAQ%3BEApTJ%2CyBAAA%3BEACA%2CqBAAA%3BEACA%2C0BAAA%3BEACA%2CiBAAA%3BEACA%2CwBAAA%3BEACQ%2CgBAAA%3B%3BAAGZ%2CKAAK%2CaAAa%3BAAqDlB%2CKAAK%2CeAAe%3BAAmDpB%2CKAAK%2CcAAc%3BAAmDnB%2CKAAK%2CYAAY%3BAAmDjB%2CKAAK%2CYAAY%3BAAmDjB%2CKAAK%2CeAAe%3BAAgDpB%2CQAAQ%3BEAhTJ%2CyBAAA%3BEACA%2C0BAAA%3B%3BAAGJ%2CKAAK%2CaAAa%3BAAoDlB%2CKAAK%2CeAAe%3BAAmDpB%2CKAAK%2CcAAc%3BAAmDnB%2CKAAK%2CYAAY%3BAAmDjB%2CKAAK%2CYAAY%3BAAmDjB%2CKAAK%2CeAAe%3BAAgDpB%2CQAAQ%3BEA%2FSJ%2CyBAAA%3BEACA%2C0BAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA%2BRJ%3BEAEI%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAoEJ%2CCAAC%3BEAGG%2CkBAAA%3BEACA%2CWAAA%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3B%3BAAGJ%2CMAAO%2CIAAG%3BEACN%2CcAAA%3B%3BAAGJ%2CQAAS%2CIAAG%3BEACR%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA8IJ%3BEACI%2CcAAA%3BEACA%2CsBAAsB%2CwBAAtB%3BEACA%2CeAAA%3BEACA%2CkBAAA%3B%3BAAGJ%3BAAAI%3BAAAI%3BAAAI%3BAAAI%3BAAAI%3BAACpB%3BAAAK%3BAAAK%3BAAAK%3BAAAK%3BAAAK%3BEACrB%2CaAAA%3BEAxEA%2CaAAa%2CgCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAA0EJ%3BAACA%3BEAII%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAII%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAII%2CkBAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEA%2FFI%2CaAAa%2CuCAAb%3BEACA%2CkBAAA%3BEACA%2CgBAAA%3BEAiGA%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BAACA%3BAACA%3BEArGI%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3BEAsGA%2CmBAAA%3BEACA%2CyBAAA%3B%3BAAGJ%3BAACA%3BEAGI%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAGI%2C2BAAA%3BEACA%2CiBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BEA9HI%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3BEAmIA%2C2BAAA%3BEACA%2CcAAA%3BEACA%2CkBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAkBJ%3BAACA%3BAACA%3BAACA%3BAACA%3BAACA%3BAACA%3BEACI%2CaAAA%3BEACA%2CsBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA8BJ%3BEACI%2CsBAAA%3BEACA%2C2BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3BEACA%2CqBAAA%3B%3BAAEA%2CCAAC%3BAACD%2CCAAC%3BEACG%2C4BAAA%3BEACA%2CcAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAsER%2CCAKI%3BAAJJ%2CEAII%3BAAHJ%2CEAGI%3BEACI%2CwBAAA%3B%3BAAIR%2CGAAI%3BEAEA%2CsBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAiBJ%3BEACI%2CqBAAA%3BEACA%2C8BAAA%3BEACA%2CmBAAA%3BEApVA%2CaAAa%2CgCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAAqVA%2CUAAE%3BAACF%2CUAAE%3BEAlVF%2CaAAa%2CuCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAAoVA%2CUAAE%3BAACF%2CUAAE%3BEA3UF%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA8VJ%3BEACI%2CkBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAoBJ%2COACI%3BAADJ%2COACQ%3BAADR%2COACY%3BAADZ%2COACgB%3BAADhB%2COACoB%3BAADpB%2COACwB%3BAADxB%2COAEI%2CWAAW%3BEACP%2C8BAAA%3B%3BAAHR%2COAMI%2CWAAW%3BEACP%2C6BAAA%22%7D */

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,65 +15,516 @@
         <h1 class="h5">cf-forms docs</h1>
       </header>
       <ul class="demo-component-list">
-        <li id="singlemulti-line-text-inputs" class="demo-component-list_item wrapper">
-          <h1 class="demo-component-list_header">Single/Multi-Line Text Inputs</h1>
+        <li id="form-labels" class="demo-component-list_item wrapper">
+          <h1 class="demo-component-list_header">Form labels</h1>
+          <ul class="demo-pattern-list">
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Default label</h3>
+                <ul class="demo_notes">
+                  <li>Warning, this pattern is still under development.</li>
+                </ul>
+              </header>
+              <section>
+<label>I am a form label</label>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;label&gt;I am a form label&lt;/label&gt;</code></pre>
+              </footer>
+            </li>
+          </ul>
+          <div class="demo-pattern-css">
+            <pre class="css"><code data-language="css">label {
+  display: block;
+}</code></pre>
+          </div>
+        </li>
+        <li id="single-line-text-input" class="demo-component-list_item wrapper">
+          <h1 class="demo-component-list_header">Single-line text input</h1>
+          <ul class="demo_notes">
+            <li>Most other text-based inputs extend styles from here as seen in the CSS to the right.</li>
+          </ul>
           <ul class="demo-pattern-list">
             <li class="demo-pattern-list_item">
               <header class="demo-pattern-list_header">
                 <h3>Default single-line text input</h3>
               </header>
               <section>
-<input placeholder="placeholder text" type="text">
+<input placeholder="placeholder text" type="text" value="">
 </section>
               <footer class="demo-pattern-list_footer">
-                <pre class="html"><code data-language="html">&lt;input placeholder=&quot;placeholder text&quot; type=&quot;text&quot;&gt;</code></pre>
+                <pre class="html"><code data-language="html">&lt;input placeholder=&quot;placeholder text&quot; type=&quot;text&quot; value=&quot;&quot;&gt;</code></pre>
               </footer>
             </li>
             <li class="demo-pattern-list_item">
               <header class="demo-pattern-list_header">
-                <h3>Focused single-line text input</h3>
+                <h3>Focused state</h3>
               </header>
               <section>
-<input class="focus" placeholder="placeholder text" type="text">
+<input class="focus" placeholder="placeholder text" type="text" value="">
 </section>
               <footer class="demo-pattern-list_footer">
-                <pre class="html"><code data-language="html">&lt;input class=&quot;focus&quot; placeholder=&quot;placeholder text&quot; type=&quot;text&quot;&gt;</code></pre>
+                <pre class="html"><code data-language="html">&lt;input class=&quot;focus&quot; placeholder=&quot;placeholder text&quot; type=&quot;text&quot; value=&quot;&quot;&gt;</code></pre>
               </footer>
             </li>
             <li class="demo-pattern-list_item">
               <header class="demo-pattern-list_header">
-                <h3>Field in error state</h3>
-                <ul class="demo_codenotes">
-                  <li>
-                    <pre class="code"><code>role=&quot;alert&quot;</code></pre>
-                  </li>
-                </ul>
+                <h3>Error state</h3>
                 <ul class="demo_notes">
-                  <li>Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role</li>
+                  <li>Please review the notes on form input error icons in the form icons section below.</li>
                 </ul>
               </header>
               <section>
-<input class="error" type="text" value="Invalid input">
-<i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
+<input class="error" placeholder="placeholder text" type="text" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
 </section>
               <footer class="demo-pattern-list_footer">
-                <pre class="html"><code data-language="html">&lt;input class=&quot;error&quot; type=&quot;text&quot; value=&quot;Invalid input&quot;&gt;
-&lt;i class=&quot;icon-remove-sign&quot; role=&quot;alert&quot;&gt;&lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;&lt;/i&gt;</code></pre>
+                <pre class="html"><code data-language="html">&lt;input class=&quot;error&quot; placeholder=&quot;placeholder text&quot; type=&quot;text&quot; value=&quot;Invalid input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-remove-sign&quot; role=&quot;alert&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
               </footer>
             </li>
             <li class="demo-pattern-list_item">
               <header class="demo-pattern-list_header">
-                <h3>Field in success state</h3>
+                <h3>Success state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input success icons in the form icons section below.</li>
+                </ul>
               </header>
               <section>
-<input class="success" type="text" value="Validated input">
-<i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
+<input class="success" placeholder="placeholder text" type="text" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
 </section>
               <footer class="demo-pattern-list_footer">
-                <pre class="html"><code data-language="html">&lt;input class=&quot;success&quot; type=&quot;text&quot; value=&quot;Validated input&quot;&gt;
-&lt;i class=&quot;icon-ok-sign&quot;&gt;&lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;&lt;/i&gt;</code></pre>
+                <pre class="html"><code data-language="html">&lt;input class=&quot;success&quot; placeholder=&quot;placeholder text&quot; type=&quot;text&quot; value=&quot;Validated input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-ok-sign&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
               </footer>
             </li>
+          </ul>
+          <div class="demo-pattern-css">
+            <pre class="css"><code data-language="css">input[type=&quot;text&quot;],
+input[type=&quot;search&quot;],
+input[type=&quot;email&quot;],
+input[type=&quot;url&quot;],
+input[type=&quot;tel&quot;],
+input[type=&quot;number&quot;],
+textarea {
+  display: inline-block;
+  width: 85%;
+  margin: 0;
+  padding: 0.25em;
+  font-family: Arial, sans-serif;
+  font-size: 1em;
+  background: #ffffff;
+  border: 1px solid #75787b;
+  border-radius: 0;
+  vertical-align: top;
+  -webkit-appearance: none;
+  -webkit-user-modify: read-write-plaintext-only;
+}
+input[type=&quot;text&quot;]:focus,
+input[type=&quot;text&quot;].focus,
+input[type=&quot;search&quot;]:focus,
+input[type=&quot;search&quot;].focus,
+input[type=&quot;email&quot;]:focus,
+input[type=&quot;email&quot;].focus,
+input[type=&quot;url&quot;]:focus,
+input[type=&quot;url&quot;].focus,
+input[type=&quot;tel&quot;]:focus,
+input[type=&quot;tel&quot;].focus,
+input[type=&quot;number&quot;]:focus,
+input[type=&quot;number&quot;].focus,
+textarea:focus,
+textarea.focus {
+  border: 1px solid #0072ce;
+  border-color: #0072ce;
+  outline: 1px solid #0072ce;
+  outline-offset: 0;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+input[type=&quot;text&quot;].error,
+input[type=&quot;search&quot;].error,
+input[type=&quot;email&quot;].error,
+input[type=&quot;url&quot;].error,
+input[type=&quot;tel&quot;].error,
+input[type=&quot;number&quot;].error,
+textarea.error {
+  border: 1px solid #d12124;
+  outline: 1px solid #d12124;
+}
+input[type=&quot;text&quot;].success,
+input[type=&quot;search&quot;].success,
+input[type=&quot;email&quot;].success,
+input[type=&quot;url&quot;].success,
+input[type=&quot;tel&quot;].success,
+input[type=&quot;number&quot;].success,
+textarea.success {
+  border: 1px solid #2cb34a;
+  outline: 1px solid #2cb34a;
+}</code></pre>
+          </div>
+        </li>
+        <li id="single-line-search-input" class="demo-component-list_item wrapper">
+          <h1 class="demo-component-list_header">Single-line search input</h1>
+          <ul class="demo-pattern-list">
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Default single-line search input</h3>
+              </header>
+              <section>
+<input placeholder="placeholder search text" type="search" value="">
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input placeholder=&quot;placeholder search text&quot; type=&quot;search&quot; value=&quot;&quot;&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Focused state</h3>
+              </header>
+              <section>
+<input class="focus" placeholder="placeholder search text" type="search" value="">
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;focus&quot; placeholder=&quot;placeholder search text&quot; type=&quot;search&quot; value=&quot;&quot;&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Error state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input error icons in the form icons section below.</li>
+                </ul>
+              </header>
+              <section>
+<input class="error" placeholder="placeholder search text" type="search" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;error&quot; placeholder=&quot;placeholder search text&quot; type=&quot;search&quot; value=&quot;Invalid input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-remove-sign&quot; role=&quot;alert&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Success state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input success icons in the form icons section below.</li>
+                </ul>
+              </header>
+              <section>
+<input class="success" placeholder="placeholder search text" type="search" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;success&quot; placeholder=&quot;placeholder search text&quot; type=&quot;search&quot; value=&quot;Validated input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-ok-sign&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+          </ul>
+          <div class="demo-pattern-css">
+            <pre class="css"><code data-language="css">/* NOTE: all input[type=&quot;search&quot;] styles extend input[type=&quot;text&quot;]. */</code></pre>
+          </div>
+        </li>
+        <li id="single-line-email-input" class="demo-component-list_item wrapper">
+          <h1 class="demo-component-list_header">Single-line email input</h1>
+          <ul class="demo-pattern-list">
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Default single-line email input</h3>
+              </header>
+              <section>
+<input placeholder="placeholder email text" type="email" value="">
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input placeholder=&quot;placeholder email text&quot; type=&quot;email&quot; value=&quot;&quot;&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Focused state</h3>
+              </header>
+              <section>
+<input class="focus" placeholder="placeholder email text" type="email" value="">
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;focus&quot; placeholder=&quot;placeholder email text&quot; type=&quot;email&quot; value=&quot;&quot;&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Error state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input error icons in the form icons section below.</li>
+                </ul>
+              </header>
+              <section>
+<input class="error" placeholder="placeholder email text" type="email" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;error&quot; placeholder=&quot;placeholder email text&quot; type=&quot;email&quot; value=&quot;Invalid input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-remove-sign&quot; role=&quot;alert&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Success state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input success icons in the form icons section below.</li>
+                </ul>
+              </header>
+              <section>
+<input class="success" placeholder="placeholder email text" type="email" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;success&quot; placeholder=&quot;placeholder email text&quot; type=&quot;email&quot; value=&quot;Validated input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-ok-sign&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+          </ul>
+          <div class="demo-pattern-css">
+            <pre class="css"><code data-language="css">/* NOTE: all input[type=&quot;email&quot;] styles extend input[type=&quot;text&quot;]. */</code></pre>
+          </div>
+        </li>
+        <li id="single-line-url-input" class="demo-component-list_item wrapper">
+          <h1 class="demo-component-list_header">Single-line url input</h1>
+          <ul class="demo-pattern-list">
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Default single-line url input</h3>
+              </header>
+              <section>
+<input placeholder="placeholder url text" type="url" value="">
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input placeholder=&quot;placeholder url text&quot; type=&quot;url&quot; value=&quot;&quot;&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Focused state</h3>
+              </header>
+              <section>
+<input class="focus" placeholder="placeholder url text" type="url" value="">
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;focus&quot; placeholder=&quot;placeholder url text&quot; type=&quot;url&quot; value=&quot;&quot;&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Error state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input error icons in the form icons section below.</li>
+                </ul>
+              </header>
+              <section>
+<input class="error" placeholder="placeholder url text" type="url" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;error&quot; placeholder=&quot;placeholder url text&quot; type=&quot;url&quot; value=&quot;Invalid input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-remove-sign&quot; role=&quot;alert&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Success state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input success icons in the form icons section below.</li>
+                </ul>
+              </header>
+              <section>
+<input class="success" placeholder="placeholder url text" type="url" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;success&quot; placeholder=&quot;placeholder url text&quot; type=&quot;url&quot; value=&quot;Validated input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-ok-sign&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+          </ul>
+          <div class="demo-pattern-css">
+            <pre class="css"><code data-language="css">/* NOTE: all input[type=&quot;url&quot;] styles extend input[type=&quot;text&quot;]. */</code></pre>
+          </div>
+        </li>
+        <li id="single-line-tel-input" class="demo-component-list_item wrapper">
+          <h1 class="demo-component-list_header">Single-line tel input</h1>
+          <ul class="demo-pattern-list">
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Default single-line tel input</h3>
+              </header>
+              <section>
+<input placeholder="placeholder tel text" type="tel" value="">
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input placeholder=&quot;placeholder tel text&quot; type=&quot;tel&quot; value=&quot;&quot;&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Focused state</h3>
+              </header>
+              <section>
+<input class="focus" placeholder="placeholder tel text" type="tel" value="">
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;focus&quot; placeholder=&quot;placeholder tel text&quot; type=&quot;tel&quot; value=&quot;&quot;&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Error state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input error icons in the form icons section below.</li>
+                </ul>
+              </header>
+              <section>
+<input class="error" placeholder="placeholder tel text" type="tel" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;error&quot; placeholder=&quot;placeholder tel text&quot; type=&quot;tel&quot; value=&quot;Invalid input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-remove-sign&quot; role=&quot;alert&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Success state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input success icons in the form icons section below.</li>
+                </ul>
+              </header>
+              <section>
+<input class="success" placeholder="placeholder tel text" type="tel" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;success&quot; placeholder=&quot;placeholder tel text&quot; type=&quot;tel&quot; value=&quot;Validated input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-ok-sign&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+          </ul>
+          <div class="demo-pattern-css">
+            <pre class="css"><code data-language="css">/* NOTE: all input[type=&quot;tel&quot;] styles extend input[type=&quot;text&quot;]. */</code></pre>
+          </div>
+        </li>
+        <li id="single-line-number-input" class="demo-component-list_item wrapper">
+          <h1 class="demo-component-list_header">Single-line number input</h1>
+          <ul class="demo-pattern-list">
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Default single-line number input</h3>
+              </header>
+              <section>
+<input placeholder="placeholder number text" type="number" value="">
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input placeholder=&quot;placeholder number text&quot; type=&quot;number&quot; value=&quot;&quot;&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Focused state</h3>
+              </header>
+              <section>
+<input class="focus" placeholder="placeholder number text" type="number" value="">
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;focus&quot; placeholder=&quot;placeholder number text&quot; type=&quot;number&quot; value=&quot;&quot;&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Error state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input error icons in the form icons section below.</li>
+                </ul>
+              </header>
+              <section>
+<input class="error" placeholder="placeholder number text" type="number" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;error&quot; placeholder=&quot;placeholder number text&quot; type=&quot;number&quot; value=&quot;Invalid input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-remove-sign&quot; role=&quot;alert&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Success state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input success icons in the form icons section below.</li>
+                </ul>
+              </header>
+              <section>
+<input class="success" placeholder="placeholder number text" type="number" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;success&quot; placeholder=&quot;placeholder number text&quot; type=&quot;number&quot; value=&quot;Validated input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-ok-sign&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+          </ul>
+          <div class="demo-pattern-css">
+            <pre class="css"><code data-language="css">/* NOTE: all input[type=&quot;number&quot;] styles extend input[type=&quot;text&quot;]. */</code></pre>
+          </div>
+        </li>
+        <li id="multiline-textarea" class="demo-component-list_item wrapper">
+          <h1 class="demo-component-list_header">Multiline textarea</h1>
+          <ul class="demo-pattern-list">
             <li class="demo-pattern-list_item">
               <header class="demo-pattern-list_header">
                 <h3>Default multi-line text box</h3>
@@ -99,89 +550,144 @@
             <li class="demo-pattern-list_item">
               <header class="demo-pattern-list_header">
                 <h3>Multi-line text box in error state</h3>
-                <ul class="demo_codenotes">
-                  <li>
-                    <pre class="code"><code>role=&quot;alert&quot;</code></pre>
-                  </li>
-                </ul>
                 <ul class="demo_notes">
-                  <li>Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role</li>
+                  <li>Please review the notes on form input error icons in the form icons section below.</li>
                 </ul>
               </header>
               <section>
 <textarea class="error">Invalid input</textarea>
-<i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
+<i class="cf-form_input-icon icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
 </section>
               <footer class="demo-pattern-list_footer">
                 <pre class="html"><code data-language="html">&lt;textarea class=&quot;error&quot;&gt;Invalid input&lt;/textarea&gt;
-&lt;i class=&quot;icon-remove-sign&quot; role=&quot;alert&quot;&gt;&lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;&lt;/i&gt;</code></pre>
+&lt;i class=&quot;cf-form_input-icon icon-remove-sign&quot; role=&quot;alert&quot;&gt;&lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;&lt;/i&gt;</code></pre>
               </footer>
             </li>
             <li class="demo-pattern-list_item">
               <header class="demo-pattern-list_header">
                 <h3>Multi-line text box in success state</h3>
+                <ul class="demo_notes">
+                  <li>Please review the notes on form input success icons in the form icons section below.</li>
+                </ul>
               </header>
               <section>
 <textarea class="success">Validated input</textarea>
-<i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
+<i class="cf-form_input-icon icon-ok-sign"><span class="jekyll-bug"></span></i>
 </section>
               <footer class="demo-pattern-list_footer">
                 <pre class="html"><code data-language="html">&lt;textarea class=&quot;success&quot;&gt;Validated input&lt;/textarea&gt;
-&lt;i class=&quot;icon-ok-sign&quot;&gt;&lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;&lt;/i&gt;</code></pre>
+&lt;i class=&quot;cf-form_input-icon icon-ok-sign&quot;&gt;&lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;&lt;/i&gt;</code></pre>
               </footer>
             </li>
           </ul>
           <div class="demo-pattern-css">
-            <pre class="css"><code data-language="css">input,
-textarea {
-  display: inline-block;
-  width: 85%;
-  margin: 0;
-  padding: 0.25em;
-  font-family: Arial, sans-serif;
-  font-size: 1em;
-  background: #ffffff;
-  border: 1px solid #75787b;
-  border-radius: 0;
-  vertical-align: top;
-  -webkit-appearance: none;
-  -webkit-user-modify: read-write-plaintext-only;
-}
+            <pre class="css"><code data-language="css">/* NOTE: all textarea styles extend input[type=&quot;text&quot;]. */
 textarea {
   overflow: auto;
-}
-input:focus,
-input.focus,
-textarea:focus,
-textarea.focus {
-  border: 1px solid #0072ce;
-  border-color: #0072ce;
-  outline: 1px solid #0072ce;
-  outline-offset: 0;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
-input.error,
-textarea.error {
-  border: 1px solid #d12124;
-  outline: 1px solid #d12124;
-}
-input.success,
-textarea.success {
-  border: 1px solid #2cb34a;
-  outline: 1px solid #2cb34a;
-}
-input + [class^=&quot;icon-&quot;],
-textarea + [class^=&quot;icon-&quot;] {
+}</code></pre>
+          </div>
+        </li>
+        <li id="form-icons" class="demo-component-list_item wrapper">
+          <h1 class="demo-component-list_header">Form icons</h1>
+          <ul class="demo-pattern-list">
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>The .jekyll-bug element</h3>
+                <ul class="demo_codenotes">
+                  <li>
+                    <pre class="code"><code>&lt;i class=&quot;cf-form_input-icon icon-credit-card&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+                  </li>
+                </ul>
+                <ul class="demo_notes">
+                  <li>
+Adding the .jekyll-bug element inside of an icon is only necessary
+when using Jekyll as it tends to ignore empty &lt;i&gt; elements.
+</li>
+                </ul>
+              </header>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Form input icons</h3>
+                <ul class="demo_notes">
+                  <li>Form input icons add small positioning tweaks to Font Awesome icons.</li>
+                  <li>They are meant to be positioned after a form input.</li>
+                </ul>
+              </header>
+              <section>
+<input type="text" value="">
+<i class="cf-form_input-icon icon-credit-card">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input type=&quot;text&quot; value=&quot;&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-credit-card&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Form input error icon</h3>
+                <ul class="demo_notes">
+                  <li>
+The icon must be placed directly after the form input in the markup
+and the input must have the class of &quot;error&quot;.
+</li>
+                  <li>Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role</li>
+                </ul>
+              </header>
+              <section>
+<input class="error" placeholder="placeholder search text" type="search" value="Invalid input">
+<i class="cf-form_input-icon icon-remove-sign" role="alert">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;error&quot; placeholder=&quot;placeholder search text&quot; type=&quot;search&quot; value=&quot;Invalid input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-remove-sign&quot; role=&quot;alert&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+            <li class="demo-pattern-list_item">
+              <header class="demo-pattern-list_header">
+                <h3>Form input success icon</h3>
+                <ul class="demo_notes">
+                  <li>
+The icon must be placed directly after the form input in the markup
+and the input must have the class of &quot;success&quot;.
+</li>
+                </ul>
+              </header>
+              <section>
+<input class="success" placeholder="placeholder search text" type="search" value="Validated input">
+<i class="cf-form_input-icon icon-ok-sign">
+  <span class="jekyll-bug"></span>
+</i>
+</section>
+              <footer class="demo-pattern-list_footer">
+                <pre class="html"><code data-language="html">&lt;input class=&quot;success&quot; placeholder=&quot;placeholder search text&quot; type=&quot;search&quot; value=&quot;Validated input&quot;&gt;
+&lt;i class=&quot;cf-form_input-icon icon-ok-sign&quot;&gt;
+  &lt;span class=&quot;jekyll-bug&quot;&gt;&lt;/span&gt;
+&lt;/i&gt;</code></pre>
+              </footer>
+            </li>
+          </ul>
+          <div class="demo-pattern-css">
+            <pre class="css"><code data-language="css">.cf-form_input-icon {
   position: relative;
   top: 0.15em;
   margin-left: 0.2em;
   font-size: 1.25em;
 }
-.error + [class^=&quot;icon-&quot;] {
+.error + .cf-form_input-icon {
   color: #d12124;
 }
-.success + [class^=&quot;icon-&quot;] {
+.success + .cf-form_input-icon {
   color: #2cb34a;
 }</code></pre>
           </div>

--- a/docs/static/css/main.css
+++ b/docs/static/css/main.css
@@ -2005,53 +2005,58 @@ a .icon-flip-vertical:before {
    Capital Framework
    Form Element Styling
    ========================================================================== */
+/* topdoc
+    name: Form labels
+    family: cf-forms
+    patterns:
+    - name: Default label
+      notes:
+        - "Warning, this pattern is still under development."
+      markup: |
+        <label>I am a form label</label>
+    tags:
+    - cf-forms
+*/
 label {
   display: block;
 }
 /* topdoc
-    name: Single/Multi-Line Text Inputs
+    name: Single-line text input
+    notes:
+      - Most other text-based inputs extend styles from here as seen in the CSS to the right.
     family: cf-forms
     patterns:
     - name: Default single-line text input
       markup: |
-        <input placeholder="placeholder text" type="text">
-    - name: Focused single-line text input
+        <input placeholder="placeholder text" type="text" value="">
+    - name: Focused state
       markup: |
-        <input class="focus" placeholder="placeholder text" type="text">
-    - name: Field in error state
-      codenotes:
-        - 'role="alert"'
+        <input class="focus" placeholder="placeholder text" type="text" value="">
+    - name: Error state
       notes:
-        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+        - Please review the notes on form input error icons in the form icons section below.
       markup: |
-        <input class="error" type="text" value="Invalid input">
-        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
-    - name: Field in success state
-      markup: |
-        <input class="success" type="text" value="Validated input">
-        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
-    - name: Default multi-line text box
-      markup: |
-        <textarea>Example entry</textarea>
-    - name: Focused multi-line text box
-      markup: |
-        <textarea class="focus">Example entry</textarea>
-    - name: Multi-line text box in error state
-      codenotes:
-        - 'role="alert"'
+        <input class="error" placeholder="placeholder text" type="text" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
       notes:
-        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+        - Please review the notes on form input success icons in the form icons section below.
       markup: |
-        <textarea class="error">Invalid input</textarea>
-        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
-    - name: Multi-line text box in success state
-      markup: |
-        <textarea class="success">Validated input</textarea>
-        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
+        <input class="success" placeholder="placeholder text" type="text" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
     tags:
     - cf-forms
 */
-input,
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="url"],
+input[type="tel"],
+input[type="number"],
 textarea {
   display: inline-block;
   width: 85%;
@@ -2066,11 +2071,18 @@ textarea {
   -webkit-appearance: none;
   -webkit-user-modify: read-write-plaintext-only;
 }
-textarea {
-  overflow: auto;
-}
-input:focus,
-input.focus,
+input[type="text"]:focus,
+input[type="text"].focus,
+input[type="search"]:focus,
+input[type="search"].focus,
+input[type="email"]:focus,
+input[type="email"].focus,
+input[type="url"]:focus,
+input[type="url"].focus,
+input[type="tel"]:focus,
+input[type="tel"].focus,
+input[type="number"]:focus,
+input[type="number"].focus,
 textarea:focus,
 textarea.focus {
   border: 1px solid #0072ce;
@@ -2080,27 +2092,262 @@ textarea.focus {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
-input.error,
+input[type="text"].error,
+input[type="search"].error,
+input[type="email"].error,
+input[type="url"].error,
+input[type="tel"].error,
+input[type="number"].error,
 textarea.error {
   border: 1px solid #d12124;
   outline: 1px solid #d12124;
 }
-input.success,
+input[type="text"].success,
+input[type="search"].success,
+input[type="email"].success,
+input[type="url"].success,
+input[type="tel"].success,
+input[type="number"].success,
 textarea.success {
   border: 1px solid #2cb34a;
   outline: 1px solid #2cb34a;
 }
-input + [class^="icon-"],
-textarea + [class^="icon-"] {
+/* topdoc
+    name: Single-line search input
+    family: cf-forms
+    patterns:
+    - name: Default single-line search input
+      markup: |
+        <input placeholder="placeholder search text" type="search" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder search text" type="search" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder search text" type="search" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder search text" type="search" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all input[type="search"] styles extend input[type="text"]. */
+/* topdoc
+    name: Single-line email input
+    family: cf-forms
+    patterns:
+    - name: Default single-line email input
+      markup: |
+        <input placeholder="placeholder email text" type="email" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder email text" type="email" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder email text" type="email" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder email text" type="email" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all input[type="email"] styles extend input[type="text"]. */
+/* topdoc
+    name: Single-line url input
+    family: cf-forms
+    patterns:
+    - name: Default single-line url input
+      markup: |
+        <input placeholder="placeholder url text" type="url" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder url text" type="url" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder url text" type="url" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder url text" type="url" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all input[type="url"] styles extend input[type="text"]. */
+/* topdoc
+    name: Single-line tel input
+    family: cf-forms
+    patterns:
+    - name: Default single-line tel input
+      markup: |
+        <input placeholder="placeholder tel text" type="tel" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder tel text" type="tel" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder tel text" type="tel" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder tel text" type="tel" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all input[type="tel"] styles extend input[type="text"]. */
+/* topdoc
+    name: Single-line number input
+    family: cf-forms
+    patterns:
+    - name: Default single-line number input
+      markup: |
+        <input placeholder="placeholder number text" type="number" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder number text" type="number" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder number text" type="number" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder number text" type="number" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all input[type="number"] styles extend input[type="text"]. */
+/* topdoc
+    name: Multiline textarea
+    family: cf-forms
+    patterns:
+    - name: Default multi-line text box
+      markup: |
+        <textarea>Example entry</textarea>
+    - name: Focused multi-line text box
+      markup: |
+        <textarea class="focus">Example entry</textarea>
+    - name: Multi-line text box in error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <textarea class="error">Invalid input</textarea>
+        <i class="cf-form_input-icon icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
+    - name: Multi-line text box in success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <textarea class="success">Validated input</textarea>
+        <i class="cf-form_input-icon icon-ok-sign"><span class="jekyll-bug"></span></i>
+    tags:
+    - cf-forms
+*/
+/* NOTE: all textarea styles extend input[type="text"]. */
+textarea {
+  overflow: auto;
+}
+/* topdoc
+    name: Form icons
+    family: cf-forms
+    patterns:
+    - name: The .jekyll-bug element
+      codenotes:
+        - |
+          <i class="cf-form_input-icon icon-credit-card">
+            <span class="jekyll-bug"></span>
+          </i>
+      notes:
+        - |
+          Adding the .jekyll-bug element inside of an icon is only necessary
+          when using Jekyll as it tends to ignore empty <i> elements.
+    - name: Form input icons
+      notes:
+        - "Form input icons add small positioning tweaks to Font Awesome icons."
+        - "They are meant to be positioned after a form input."
+      markup: |
+        <input type="text" value="">
+        <i class="cf-form_input-icon icon-credit-card">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Form input error icon
+      notes:
+        - |
+          The icon must be placed directly after the form input in the markup
+          and the input must have the class of "error".
+        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+      markup: |
+        <input class="error" placeholder="placeholder search text" type="search" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Form input success icon
+      notes:
+        - |
+          The icon must be placed directly after the form input in the markup
+          and the input must have the class of "success".
+      markup: |
+        <input class="success" placeholder="placeholder search text" type="search" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+.cf-form_input-icon {
   position: relative;
   top: 0.15em;
   margin-left: 0.2em;
   font-size: 1.25em;
 }
-.error + [class^="icon-"] {
+.error + .cf-form_input-icon {
   color: #d12124;
 }
-.success + [class^="icon-"] {
+.success + .cf-form_input-icon {
   color: #2cb34a;
 }
 /* topdoc
@@ -2488,4 +2735,4 @@ ul {
   name: EOF
   eof: true
 */
-/*# sourceMappingURL=data:application/json,%7B%22version%22%3A3%2C%22sources%22%3A%5B%22src%2Fvendor%2Fcf-concat%2Fcf.less%22%5D%2C%22names%22%3A%5B%5D%2C%22mappings%22%3A%22%3B%3B%3B%3BAAKA%3BEACI%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA%2BCJ%3BAACA%3BEAGI%2CqBAAA%3BEACA%2CUAAA%3BEACA%2CSAAA%3BEACA%2CeAAA%3BEACA%2C8BAAA%3BEACA%2CcAAA%3BEACA%2CmBAAA%3BEACA%2CyBAAA%3BEACA%2CwBAAA%3BEACG%2CqBAAA%3BEACK%2CgBAAA%3BEACR%2CmBAAA%3BEACA%2CwBAAA%3BEACA%2C8CAAA%3B%3BAAGJ%3BEACE%2CcAAA%3B%3BAAGF%2CKAAK%3BAACL%2CKAAK%3BAACL%2CQAAQ%3BAACR%2CQAAQ%3BEAEJ%2CyBAAA%3BEACA%2CqBAAA%3BEACA%2C0BAAA%3BEACA%2CiBAAA%3BEACA%2CwBAAA%3BEACQ%2CgBAAA%3B%3BAAGZ%2CKAAK%3BAACL%2CQAAQ%3BEACJ%2CyBAAA%3BEACA%2C0BAAA%3B%3BAAGJ%2CKAAK%3BAACL%2CQAAQ%3BEACJ%2CyBAAA%3BEACA%2C0BAAA%3B%3BAAGJ%2CKAAM%3BAACN%2CQAAS%3BEAGL%2CkBAAA%3BEACA%2CWAAA%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3B%3BAAGJ%2CMAAO%3BEACH%2CcAAA%3B%3BAAGJ%2CQAAS%3BEACL%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA6IJ%3BEACI%2CcAAA%3BEACA%2CsBAAsB%2CwBAAtB%3BEACA%2CeAAA%3BEACA%2CkBAAA%3B%3BAAGJ%3BAAAI%3BAAAI%3BAAAI%3BAAAI%3BAAAI%3BAACpB%3BAAAK%3BAAAK%3BAAAK%3BAAAK%3BAAAK%3BEACrB%2CaAAA%3BEAxEA%2CaAAa%2CgCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAA0EJ%3BAACA%3BEAII%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAII%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAII%2CkBAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEA%2FFI%2CaAAa%2CuCAAb%3BEACA%2CkBAAA%3BEACA%2CgBAAA%3BEAiGA%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BAACA%3BAACA%3BEArGI%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3BEAsGA%2CmBAAA%3BEACA%2CyBAAA%3B%3BAAGJ%3BAACA%3BEAGI%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAGI%2C2BAAA%3BEACA%2CiBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BEA9HI%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3BEAmIA%2C2BAAA%3BEACA%2CcAAA%3BEACA%2CkBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAkBJ%3BAACA%3BAACA%3BAACA%3BAACA%3BAACA%3BAACA%3BEACI%2CaAAA%3BEACA%2CsBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA8BJ%3BEACI%2CsBAAA%3BEACA%2C2BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3BEACA%2CqBAAA%3B%3BAAEA%2CCAAC%3BAACD%2CCAAC%3BEACG%2C4BAAA%3BEACA%2CcAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAsER%2CCAKI%3BAAJJ%2CEAII%3BAAHJ%2CEAGI%3BEACI%2CwBAAA%3B%3BAAIR%2CGAAI%3BEAEA%2CsBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAiBJ%3BEACI%2CqBAAA%3BEACA%2C8BAAA%3BEACA%2CmBAAA%3BEApVA%2CaAAa%2CgCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAAqVA%2CUAAE%3BAACF%2CUAAE%3BEAlVF%2CaAAa%2CuCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAAoVA%2CUAAE%3BAACF%2CUAAE%3BEA3UF%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA8VJ%3BEACI%2CkBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAoBJ%2COACI%3BAADJ%2COACQ%3BAADR%2COACY%3BAADZ%2COACgB%3BAADhB%2COACoB%3BAADpB%2COACwB%3BAADxB%2COAEI%2CWAAW%3BEACP%2C8BAAA%3B%3BAAHR%2COAMI%2CWAAW%3BEACP%2C6BAAA%22%7D */
+/*# sourceMappingURL=data:application/json,%7B%22version%22%3A3%2C%22sources%22%3A%5B%22src%2Fvendor%2Fcf-concat%2Fcf.less%22%5D%2C%22names%22%3A%5B%5D%2C%22mappings%22%3A%22%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAmBA%3BEACI%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAoCJ%2CKAAK%3BAAyEL%2CKAAK%3BAAmDL%2CKAAK%3BAAmDL%2CKAAK%3BAAmDL%2CKAAK%3BAAmDL%2CKAAK%3BAA%2BCL%3BEAjUI%2CqBAAA%3BEACA%2CUAAA%3BEACA%2CSAAA%3BEACA%2CeAAA%3BEACA%2C8BAAA%3BEACA%2CcAAA%3BEACA%2CmBAAA%3BEACA%2CyBAAA%3BEACA%2CwBAAA%3BEACG%2CqBAAA%3BEACK%2CgBAAA%3BEACR%2CmBAAA%3BEACA%2CwBAAA%3BEACA%2C8CAAA%3B%3BAAGJ%2CKAAK%2CaAAa%3BAAClB%2CKAAK%2CaAAa%3BAAyDlB%2CKAAK%2CeAAe%3BAACpB%2CKAAK%2CeAAe%3BAAkDpB%2CKAAK%2CcAAc%3BAACnB%2CKAAK%2CcAAc%3BAAkDnB%2CKAAK%2CYAAY%3BAACjB%2CKAAK%2CYAAY%3BAAkDjB%2CKAAK%2CYAAY%3BAACjB%2CKAAK%2CYAAY%3BAAkDjB%2CKAAK%2CeAAe%3BAACpB%2CKAAK%2CeAAe%3BAA%2BCpB%2CQAAQ%3BAACR%2CQAAQ%3BEApTJ%2CyBAAA%3BEACA%2CqBAAA%3BEACA%2C0BAAA%3BEACA%2CiBAAA%3BEACA%2CwBAAA%3BEACQ%2CgBAAA%3B%3BAAGZ%2CKAAK%2CaAAa%3BAAqDlB%2CKAAK%2CeAAe%3BAAmDpB%2CKAAK%2CcAAc%3BAAmDnB%2CKAAK%2CYAAY%3BAAmDjB%2CKAAK%2CYAAY%3BAAmDjB%2CKAAK%2CeAAe%3BAAgDpB%2CQAAQ%3BEAhTJ%2CyBAAA%3BEACA%2C0BAAA%3B%3BAAGJ%2CKAAK%2CaAAa%3BAAoDlB%2CKAAK%2CeAAe%3BAAmDpB%2CKAAK%2CcAAc%3BAAmDnB%2CKAAK%2CYAAY%3BAAmDjB%2CKAAK%2CYAAY%3BAAmDjB%2CKAAK%2CeAAe%3BAAgDpB%2CQAAQ%3BEA%2FSJ%2CyBAAA%3BEACA%2C0BAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA%2BRJ%3BEAEI%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAoEJ%2CCAAC%3BEAGG%2CkBAAA%3BEACA%2CWAAA%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3B%3BAAGJ%2CMAAO%2CIAAG%3BEACN%2CcAAA%3B%3BAAGJ%2CQAAS%2CIAAG%3BEACR%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA8IJ%3BEACI%2CcAAA%3BEACA%2CsBAAsB%2CwBAAtB%3BEACA%2CeAAA%3BEACA%2CkBAAA%3B%3BAAGJ%3BAAAI%3BAAAI%3BAAAI%3BAAAI%3BAAAI%3BAACpB%3BAAAK%3BAAAK%3BAAAK%3BAAAK%3BAAAK%3BEACrB%2CaAAA%3BEAxEA%2CaAAa%2CgCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAA0EJ%3BAACA%3BEAII%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAII%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAII%2CkBAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEA%2FFI%2CaAAa%2CuCAAb%3BEACA%2CkBAAA%3BEACA%2CgBAAA%3BEAiGA%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BAACA%3BAACA%3BEArGI%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3BEAsGA%2CmBAAA%3BEACA%2CyBAAA%3B%3BAAGJ%3BAACA%3BEAGI%2C2BAAA%3BEACA%2CkBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BAACA%3BEAGI%2C2BAAA%3BEACA%2CiBAAA%3BEACA%2CuBAAA%3B%3BAAGJ%3BEA9HI%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3BEAmIA%2C2BAAA%3BEACA%2CcAAA%3BEACA%2CkBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAkBJ%3BAACA%3BAACA%3BAACA%3BAACA%3BAACA%3BAACA%3BEACI%2CaAAA%3BEACA%2CsBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA8BJ%3BEACI%2CsBAAA%3BEACA%2C2BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3BEACA%2CqBAAA%3B%3BAAEA%2CCAAC%3BAACD%2CCAAC%3BEACG%2C4BAAA%3BEACA%2CcAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3B%3BAAGJ%2CCAAC%3BAACD%2CCAAC%3BEACG%2C0BAAA%3BEACA%2C4BAAA%3BEACA%2CcAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAsER%2CCAKI%3BAAJJ%2CEAII%3BAAHJ%2CEAGI%3BEACI%2CwBAAA%3B%3BAAIR%2CGAAI%3BEAEA%2CsBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAiBJ%3BEACI%2CqBAAA%3BEACA%2C8BAAA%3BEACA%2CmBAAA%3BEApVA%2CaAAa%2CgCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAAqVA%2CUAAE%3BAACF%2CUAAE%3BEAlVF%2CaAAa%2CuCAAb%3BEACA%2CkBAAA%3BEACA%2CmBAAA%3B%3BAAoVA%2CUAAE%3BAACF%2CUAAE%3BEA3UF%2CaAAa%2CqCAAb%3BEACA%2CkBAAA%3BEACA%2CiBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAA8VJ%3BEACI%2CkBAAA%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3B%3BAAoBJ%2COACI%3BAADJ%2COACQ%3BAADR%2COACY%3BAADZ%2COACgB%3BAADhB%2COACoB%3BAADpB%2COACwB%3BAADxB%2COAEI%2CWAAW%3BEACP%2C8BAAA%3B%3BAAHR%2COAMI%2CWAAW%3BEACP%2C6BAAA%22%7D */

--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -3,56 +3,58 @@
    Form Element Styling
    ========================================================================== */
 
-label {
-    display: block;
-}
 
 /* topdoc
-    name: Single/Multi-Line Text Inputs
+    name: Form labels
     family: cf-forms
     patterns:
-    - name: Default single-line text input
-      markup: |
-        <input placeholder="placeholder text" type="text">
-    - name: Focused single-line text input
-      markup: |
-        <input class="focus" placeholder="placeholder text" type="text">
-    - name: Field in error state
-      codenotes:
-        - 'role="alert"'
+    - name: Default label
       notes:
-        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+        - "Warning, this pattern is still under development."
       markup: |
-        <input class="error" type="text" value="Invalid input">
-        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
-    - name: Field in success state
-      markup: |
-        <input class="success" type="text" value="Validated input">
-        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
-    - name: Default multi-line text box
-      markup: |
-        <textarea>Example entry</textarea>
-    - name: Focused multi-line text box
-      markup: |
-        <textarea class="focus">Example entry</textarea>
-    - name: Multi-line text box in error state
-      codenotes:
-        - 'role="alert"'
-      notes:
-        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
-      markup: |
-        <textarea class="error">Invalid input</textarea>
-        <i class="icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
-    - name: Multi-line text box in success state
-      markup: |
-        <textarea class="success">Validated input</textarea>
-        <i class="icon-ok-sign"><span class="jekyll-bug"></span></i>
+        <label>I am a form label</label>
     tags:
     - cf-forms
 */
 
-input,
-textarea {
+label {
+    display: block;
+}
+
+
+/* topdoc
+    name: Single-line text input
+    notes:
+      - Most other text-based inputs extend styles from here as seen in the CSS to the right.
+    family: cf-forms
+    patterns:
+    - name: Default single-line text input
+      markup: |
+        <input placeholder="placeholder text" type="text" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder text" type="text" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder text" type="text" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder text" type="text" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+
+input[type="text"] {
     @font-size: 16px;
 
     display: inline-block;
@@ -71,14 +73,8 @@ textarea {
     -webkit-user-modify: read-write-plaintext-only;
 }
 
-textarea {
-  overflow: auto; // http://css-tricks.com/textarea-tricks/
-}
-
-input:focus,
-input.focus,
-textarea:focus,
-textarea.focus {
+input[type="text"]:focus,
+input[type="text"].focus {
     // Class included for static state examples
     border: 1px solid @pacific;
     border-color: @pacific;
@@ -88,20 +84,371 @@ textarea.focus {
             box-shadow: none;
 }
 
-input.error,
-textarea.error {
+input[type="text"].error {
     border: 1px solid @redorange;
     outline: 1px solid @redorange;
 }
 
-input.success,
-textarea.success {
+input[type="text"].success {
     border: 1px solid @green;
     outline: 1px solid @green;
 }
 
-input + [class^="icon-"],
-textarea + [class^="icon-"] {
+
+/* topdoc
+    name: Single-line search input
+    family: cf-forms
+    patterns:
+    - name: Default single-line search input
+      markup: |
+        <input placeholder="placeholder search text" type="search" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder search text" type="search" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder search text" type="search" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder search text" type="search" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+
+/* NOTE: all input[type="search"] styles extend input[type="text"]. */
+
+input[type="search"] {
+    &:extend(input[type="text"]);
+}
+
+input[type="search"]:focus,
+input[type="search"].focus {
+    // Class included for static state examples
+    &:extend(input[type="text"]:focus);
+}
+
+input[type="search"].error {
+    &:extend(input[type="text"].error);
+}
+
+input[type="search"].success {
+    &:extend(input[type="text"].success);
+}
+
+
+/* topdoc
+    name: Single-line email input
+    family: cf-forms
+    patterns:
+    - name: Default single-line email input
+      markup: |
+        <input placeholder="placeholder email text" type="email" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder email text" type="email" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder email text" type="email" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder email text" type="email" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+
+/* NOTE: all input[type="email"] styles extend input[type="text"]. */
+
+input[type="email"] {
+    &:extend(input[type="text"]);
+}
+
+input[type="email"]:focus,
+input[type="email"].focus {
+    // Class included for static state examples
+    &:extend(input[type="text"]:focus);
+}
+
+input[type="email"].error {
+    &:extend(input[type="text"].error);
+}
+
+input[type="email"].success {
+    &:extend(input[type="text"].success);
+}
+
+
+/* topdoc
+    name: Single-line url input
+    family: cf-forms
+    patterns:
+    - name: Default single-line url input
+      markup: |
+        <input placeholder="placeholder url text" type="url" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder url text" type="url" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder url text" type="url" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder url text" type="url" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+
+/* NOTE: all input[type="url"] styles extend input[type="text"]. */
+
+input[type="url"] {
+    &:extend(input[type="text"]);
+}
+
+input[type="url"]:focus,
+input[type="url"].focus {
+    // Class included for static state examples
+    &:extend(input[type="text"]:focus);
+}
+
+input[type="url"].error {
+    &:extend(input[type="text"].error);
+}
+
+input[type="url"].success {
+    &:extend(input[type="text"].success);
+}
+
+
+/* topdoc
+    name: Single-line tel input
+    family: cf-forms
+    patterns:
+    - name: Default single-line tel input
+      markup: |
+        <input placeholder="placeholder tel text" type="tel" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder tel text" type="tel" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder tel text" type="tel" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder tel text" type="tel" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+
+/* NOTE: all input[type="tel"] styles extend input[type="text"]. */
+
+input[type="tel"] {
+    &:extend(input[type="text"]);
+}
+
+input[type="tel"]:focus,
+input[type="tel"].focus {
+    // Class included for static state examples
+    &:extend(input[type="text"]:focus);
+}
+
+input[type="tel"].error {
+    &:extend(input[type="text"].error);
+}
+
+input[type="tel"].success {
+    &:extend(input[type="text"].success);
+}
+
+
+/* topdoc
+    name: Single-line number input
+    family: cf-forms
+    patterns:
+    - name: Default single-line number input
+      markup: |
+        <input placeholder="placeholder number text" type="number" value="">
+    - name: Focused state
+      markup: |
+        <input class="focus" placeholder="placeholder number text" type="number" value="">
+    - name: Error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <input class="error" placeholder="placeholder number text" type="number" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <input class="success" placeholder="placeholder number text" type="number" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+
+/* NOTE: all input[type="number"] styles extend input[type="text"]. */
+
+input[type="number"] {
+    &:extend(input[type="text"]);
+}
+
+input[type="number"]:focus,
+input[type="number"].focus {
+    // Class included for static state examples
+    &:extend(input[type="text"]:focus);
+}
+
+input[type="number"].error {
+    &:extend(input[type="text"].error);
+}
+
+input[type="number"].success {
+    &:extend(input[type="text"].success);
+}
+
+
+/* topdoc
+    name: Multiline textarea
+    family: cf-forms
+    patterns:
+    - name: Default multi-line text box
+      markup: |
+        <textarea>Example entry</textarea>
+    - name: Focused multi-line text box
+      markup: |
+        <textarea class="focus">Example entry</textarea>
+    - name: Multi-line text box in error state
+      notes:
+        - Please review the notes on form input error icons in the form icons section below.
+      markup: |
+        <textarea class="error">Invalid input</textarea>
+        <i class="cf-form_input-icon icon-remove-sign" role="alert"><span class="jekyll-bug"></span></i>
+    - name: Multi-line text box in success state
+      notes:
+        - Please review the notes on form input success icons in the form icons section below.
+      markup: |
+        <textarea class="success">Validated input</textarea>
+        <i class="cf-form_input-icon icon-ok-sign"><span class="jekyll-bug"></span></i>
+    tags:
+    - cf-forms
+*/
+
+/* NOTE: all textarea styles extend input[type="text"]. */
+
+textarea {
+    &:extend(input[type="text"]);
+    overflow: auto; // http://css-tricks.com/textarea-tricks/
+}
+
+textarea:focus,
+textarea.focus {
+    // Class included for static state examples
+    &:extend(input[type="text"]:focus);
+}
+
+textarea.error {
+    &:extend(input[type="text"].error);
+}
+
+textarea.success {
+    &:extend(input[type="text"].success);
+}
+
+
+/* topdoc
+    name: Form icons
+    family: cf-forms
+    patterns:
+    - name: The .jekyll-bug element
+      codenotes:
+        - |
+          <i class="cf-form_input-icon icon-credit-card">
+            <span class="jekyll-bug"></span>
+          </i>
+      notes:
+        - |
+          Adding the .jekyll-bug element inside of an icon is only necessary
+          when using Jekyll as it tends to ignore empty <i> elements.
+    - name: Form input icons
+      notes:
+        - "Form input icons add small positioning tweaks to Font Awesome icons."
+        - "They are meant to be positioned after a form input."
+      markup: |
+        <input type="text" value="">
+        <i class="cf-form_input-icon icon-credit-card">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Form input error icon
+      notes:
+        - |
+          The icon must be placed directly after the form input in the markup
+          and the input must have the class of "error".
+        - 'Use the alert role to mark invalid fields: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role'
+      markup: |
+        <input class="error" placeholder="placeholder search text" type="search" value="Invalid input">
+        <i class="cf-form_input-icon icon-remove-sign" role="alert">
+          <span class="jekyll-bug"></span>
+        </i>
+    - name: Form input success icon
+      notes:
+        - |
+          The icon must be placed directly after the form input in the markup
+          and the input must have the class of "success".
+      markup: |
+        <input class="success" placeholder="placeholder search text" type="search" value="Validated input">
+        <i class="cf-form_input-icon icon-ok-sign">
+          <span class="jekyll-bug"></span>
+        </i>
+    tags:
+    - cf-forms
+*/
+
+@cf-forms_input-icon-class: cf-form_input-icon;
+
+.@{cf-forms_input-icon-class} {
     @font-size: 20px;
 
     position: relative;
@@ -110,13 +457,14 @@ textarea + [class^="icon-"] {
     font-size: unit( @font-size / @base-font-size-px, em );
 }
 
-.error + [class^="icon-"] {
+.error + .@{cf-forms_input-icon-class} {
     color: @redorange;
 }
 
-.success + [class^="icon-"] {
+.success + .@{cf-forms_input-icon-class} {
     color: @green;
 }
+
 
 /* topdoc
   name: EOF


### PR DESCRIPTION
Refactored to limit text based input styling scope to avoid styling checkboxes and radio buttons and anything else that isn't a text input.
- Preview of the updated docs: http://himedlooff.github.io/cf-forms/docs/.
- Preview of the updated demo: http://himedlooff.github.io/cf-forms/demo/ (notice how I added a checkbox and radio button to make sure the styles aren't too aggressive).

The method I used to fix this was to use the [extend method in Less](http://lesscss.org/features/#extend-feature). This allows us to have a docs section on each input type while keeping the amount of duplicate CSS to a minimum. To get here required a little bit of refactoring for form icon usage. You now have to specify `.cf-form_input-icon` on each icon that you want to use after a text input. This keeps base styling for form icons a little easier to target. This also allows us to have a nice little docs section on form icon usage.
