### PR TITLE
Home, home on the range

### DIFF
--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -481,7 +481,7 @@ input[type=range]::-webkit-slider-runnable-track {
 }
 
 input[type=range]::-moz-range-track {
-  background: $color-primary;
+  background: @input-bg;
   border: 1px solid #757575;
   cursor: pointer;
   height: 1.2rem;
@@ -538,15 +538,15 @@ input[type=range]::-ms-fill-upper {
 }
 
 input[type=range]:focus::-webkit-slider-thumb {
-  border: 2px solid $color-focus;
+  border: 2px solid @input-border-focus;
 }
 
 input[type=range]:focus::-moz-range-thumb {
-  border: 2px solid $color-focus;
+  border: 2px solid @input-border-focus;
 }
 
 input[type=range]:focus::-ms-thumb {
-  border: 2px solid $color-focus;
+  border: 2px solid @input-border-focus;
 }
 
 

--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -469,101 +469,89 @@ textarea {
 */
 
 input[type=range] {
-  -webkit-appearance: none;
-  border: none;
-  padding-left: 0;
-  width: 100%;
-}
-
-input[type=range]:focus {
-  box-shadow: none;
-  outline: none;
-}
-
-input[type=range]::-webkit-slider-runnable-track {
-  background: @input-range-bg;
-  border: 1px solid @input-range-border;
-  border-radius: 8px;
-  cursor: pointer;
-  height: 11px;
-  width: 100%;
-}
-
-input[type=range]::-moz-range-track {
-  background: @input-range-bg;
-  border: 1px solid @input-range-border;
-  cursor: pointer;
-  height: 11px;
-  width: 100%;
-}
-
-input[type=range]::-ms-track {
-  background: transparent;
-  color: transparent;
-  cursor: pointer;
-  height: 11px;
-  width: 100%;
-}
-
-input[type=range]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  border: 1px solid @input-range-border;
-  height: 45px;
-  border-radius: 50%;
-  background: @input-range-handle;
-  cursor: pointer;
-  margin-top: -18px;  
-  width: 45px;
-}
-
-input[type=range]::-moz-range-thumb {
-  background: @input-range-handle;
-  border: 1px solid @input-range-border;
-  border-radius: 50%;
-  cursor: pointer;
-  height: 45px;
-  width: 45px;
-}
-
-input[type=range]::-ms-thumb {
-  background: @input-range-handle;
-  border: 1px solid @input-range-border;
-  border-radius: 50%;
-  cursor: pointer;
-  height: 45px;
-  width: 45px;
-}
-
-input[type=range]::-ms-fill-lower {
-  background: @input-range-bg;
-  border: 1px solid @input-range-border;
-  border-radius: 2rem;
-}
-
-input[type=range]::-ms-fill-upper {
-  background: @input-range-bg;
-  border: 1px solid @input-range-border;
-  border-radius: 2rem;
-}
-
-input[type=range]:focus,
-input[type=range].focus {
+    margin-top: 15px;
+    -webkit-appearance: none;
+    border: none;
+    padding-left: 0;
+    width: 100%;
+    &::-webkit-slider-runnable-track {
+        background: @input-range-bg;
+        border: 1px solid @input-range-border;
+        border-radius: 8px;
+        cursor: pointer;
+        height: 11px;
+        width: 100%;
+    }
+    &::-moz-range-track {
+        background: @input-range-bg;
+        border: 1px solid @input-range-border;
+        cursor: pointer;
+        height: 11px;
+        width: 100%;
+    }
+    &::-ms-track {
+        background: transparent;
+        color: transparent;
+        cursor: pointer;
+        height: 11px;
+        width: 100%;
+    }
     &::-webkit-slider-thumb {
-        background: @input-inset-selected;
-        border: 2px solid @input-border-focus;
+        -webkit-appearance: none;
+        border: 1px solid @input-range-border;
+        height: 45px;
+        border-radius: 50%;
+        background: @input-range-handle;
+        cursor: pointer;
+        margin-top: -18px;  
+        width: 45px;
     }
-
     &::-moz-range-thumb {
-        background: @input-inset-selected;
-        border: 2px solid @input-border-focus;
+        background: @input-range-handle;
+        border: 1px solid @input-range-border;
+        border-radius: 50%;
+        cursor: pointer;
+        height: 45px;
+        width: 45px;
     }
-
     &::-ms-thumb {
-        background: @input-inset-selected;
-        border: 2px solid @input-border-focus;
+        background: @input-range-handle;
+        border: 1px solid @input-range-border;
+        border-radius: 50%;
+        cursor: pointer;
+        height: 45px;
+        width: 45px;
+    }
+    &::-ms-fill-lower {
+        background: @input-range-bg;
+        border: 1px solid @input-range-border;
+        border-radius: 2rem;
+    }
+    &::-ms-fill-upper {
+        background: @input-range-bg;
+        border: 1px solid @input-range-border;
+        border-radius: 2rem;
+    }
+    &:focus,
+    &.focus {
+        box-shadow: none;
+        outline: none;
+        &::-webkit-slider-thumb {
+            background: @input-inset-selected;
+            border: 2px solid @input-border-focus;
+        }
+
+        &::-moz-range-thumb {
+            background: @input-inset-selected;
+            border: 2px solid @input-border-focus;
+        }
+
+        &::-ms-thumb {
+            background: @input-inset-selected;
+            border: 2px solid @input-border-focus;
+        }
     }
 }
-
 
 /* topdoc
   name: EOF

--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -45,9 +45,9 @@
 @input-success:                 #009d38;
 
 // range input
-@input-range-bg:                @gray-80;
-@input-range-border:            @gray-50;
-@input-range-handle:            @gray-10;
+@input-range-bg:                #329d83;
+@input-range-border:            #009d88;
+@input-range-handle:            #dddd38;
 
 // Sizing variables
 

--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -469,58 +469,58 @@ textarea {
 */
 
 input[type=range] {
+    width: 100%;
+    padding-left: 0;
     margin: 15px 0;
     -webkit-appearance: none;
     border: none;
-    padding-left: 0;
-    width: 100%;
     &::-webkit-slider-runnable-track {
+        width: 100%;
+        height: 11px;
         background: @input-range-bg;
         border: 1px solid @input-range-border;
         border-radius: 8px;
-        cursor: pointer;
-        height: 11px;
-        width: 100%;
+        cursor: pointer;        
     }
     &::-moz-range-track {
+        width: 100%;
+        height: 11px;
         background: @input-range-bg;
         border: 1px solid @input-range-border;
         cursor: pointer;
-        height: 11px;
-        width: 100%;
     }
     &::-ms-track {
+        width: 100%;
+        height: 11px;
         background: transparent;
         color: transparent;
         cursor: pointer;
-        height: 11px;
-        width: 100%;
     }
     &::-webkit-slider-thumb {
+        width: 45px;
+        height: 45px;
+        margin-top: -18px;  
         -webkit-appearance: none;
         border: 1px solid @input-range-border;
-        height: 45px;
         border-radius: 50%;
         background: @input-range-handle;
         cursor: pointer;
-        margin-top: -18px;  
-        width: 45px;
     }
     &::-moz-range-thumb {
+        width: 45px;
+        height: 45px;
         background: @input-range-handle;
         border: 1px solid @input-range-border;
         border-radius: 50%;
         cursor: pointer;
-        height: 45px;
-        width: 45px;
     }
     &::-ms-thumb {
+        width: 45px;
+        height: 45px;
         background: @input-range-handle;
         border: 1px solid @input-range-border;
         border-radius: 50%;
         cursor: pointer;
-        height: 45px;
-        width: 45px;
     }
     &::-ms-fill-lower {
         background: @input-range-bg;

--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -469,7 +469,7 @@ textarea {
 */
 
 input[type=range] {
-    margin-top: 15px;
+    margin: 15px 0;
     -webkit-appearance: none;
     border: none;
     padding-left: 0;

--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -448,6 +448,18 @@ textarea {
 
 }
 
+/* topdoc
+  name: Range input
+  family: cf-forms
+  patterns:
+    - name: Range slider input
+      markup: |
+        <label for="range-slider">Range Slider</label>
+        <input id="range-slider" type="range" min="0" max="100">
+  tags:
+    - cf-forms
+*/
+
 input[type=range] {
   -webkit-appearance: none;
   border: none;

--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -512,7 +512,7 @@ input[type=range]::-webkit-slider-thumb {
   border-radius: 50%;
   background: @input-range-handle;
   cursor: pointer;
-  margin-top: -.65rem;  
+  margin-top: -18px;  
   width: 45px;
 }
 
@@ -546,7 +546,8 @@ input[type=range]::-ms-fill-upper {
   border-radius: 2rem;
 }
 
-input[type=range]:focus {
+input[type=range]:focus,
+input[type=range].focus {
     &::-webkit-slider-thumb {
         background: @input-inset-selected;
         border: 2px solid @input-border-focus;

--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -21,6 +21,9 @@
         @input-error
         @input-warning
         @input-success
+        @input-range-bg
+        @input-range-border
+        @input-range-handle
   - name: Sizing
     codenotes:
       - |
@@ -35,11 +38,16 @@
 // .error
 @input-error:                   #ea130b;
 
-// warning
+// .warning
 @input-warning:                 #ffb108;
 
 // .success
 @input-success:                 #009d38;
+
+// range input
+@input-range-bg:                @gray-80;
+@input-range-border:            @gray-50;
+@input-range-handle:            @gray-10;
 
 // Sizing variables
 
@@ -473,18 +481,19 @@ input[type=range]:focus {
 }
 
 input[type=range]::-webkit-slider-runnable-track {
-  background: #bdbdbd;
-  border: 1px solid #757575;
+  background: @input-range-bg;
+  border: 1px solid @input-range-border;
+  border-radius: 8px;
   cursor: pointer;
-  height: 1.2rem;
+  height: 11px;
   width: 100%;
 }
 
 input[type=range]::-moz-range-track {
-  background: @input-bg;
-  border: 1px solid #757575;
+  background: @input-range-bg;
+  border: 1px solid @input-range-border;
   cursor: pointer;
-  height: 1.2rem;
+  height: 11px;
   width: 100%;
 }
 
@@ -492,24 +501,24 @@ input[type=range]::-ms-track {
   background: transparent;
   color: transparent;
   cursor: pointer;
-  height: 1.2rem;
+  height: 11px;
   width: 100%;
 }
 
 input[type=range]::-webkit-slider-thumb {
   -webkit-appearance: none;
-  border: 1px solid #757575;
+  border: 1px solid @input-range-border;
   height: 2.2rem;
   border-radius: 1.5rem;
-  background: #eeeeee;
+  background: @input-range-handle;
   cursor: pointer;
   margin-top: -.65rem;  
   width: 2.2rem;
 }
 
 input[type=range]::-moz-range-thumb {
-  background: #eeeeee;
-  border: 1px solid #757575;
+  background: @input-range-handle;
+  border: 1px solid @input-range-border;
   border-radius: 1.5rem;
   cursor: pointer;
   height: 2.2rem;
@@ -517,8 +526,8 @@ input[type=range]::-moz-range-thumb {
 }
 
 input[type=range]::-ms-thumb {
-  background: #eeeeee;
-  border: 1px solid #757575;
+  background: @input-range-handle;
+  border: 1px solid @input-range-border;
   border-radius: 1.5rem;
   cursor: pointer;
   height: 2.2rem;
@@ -526,14 +535,14 @@ input[type=range]::-ms-thumb {
 }
 
 input[type=range]::-ms-fill-lower {
-  background: #bdbdbd;
-  border: 1px solid #757575;
+  background: @input-range-bg;
+  border: 1px solid @input-range-border;
   border-radius: 2rem;
 }
 
 input[type=range]::-ms-fill-upper {
-  background: #bdbdbd;
-  border: 1px solid #757575;
+  background: @input-range-bg;
+  border: 1px solid @input-range-border;
   border-radius: 2rem;
 }
 

--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -448,6 +448,95 @@ textarea {
 
 }
 
+input[type=range] {
+  -webkit-appearance: none;
+  border: none;
+  padding-left: 0;
+  width: 100%;
+}
+
+input[type=range]:focus {
+  box-shadow: none;
+  outline: none;
+}
+
+input[type=range]::-webkit-slider-runnable-track {
+  background: #bdbdbd;
+  border: 1px solid #757575;
+  cursor: pointer;
+  height: 1.2rem;
+  width: 100%;
+}
+
+input[type=range]::-moz-range-track {
+  background: $color-primary;
+  border: 1px solid #757575;
+  cursor: pointer;
+  height: 1.2rem;
+  width: 100%;
+}
+
+input[type=range]::-ms-track {
+  background: transparent;
+  color: transparent;
+  cursor: pointer;
+  height: 1.2rem;
+  width: 100%;
+}
+
+input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  border: 1px solid #757575;
+  height: 2.2rem;
+  border-radius: 1.5rem;
+  background: #eeeeee;
+  cursor: pointer;
+  margin-top: -.65rem;  
+  width: 2.2rem;
+}
+
+input[type=range]::-moz-range-thumb {
+  background: #eeeeee;
+  border: 1px solid #757575;
+  border-radius: 1.5rem;
+  cursor: pointer;
+  height: 2.2rem;
+  width: 2.2rem;
+}
+
+input[type=range]::-ms-thumb {
+  background: #eeeeee;
+  border: 1px solid #757575;
+  border-radius: 1.5rem;
+  cursor: pointer;
+  height: 2.2rem;
+  width: 2.2rem;
+}
+
+input[type=range]::-ms-fill-lower {
+  background: #bdbdbd;
+  border: 1px solid #757575;
+  border-radius: 2rem;
+}
+
+input[type=range]::-ms-fill-upper {
+  background: #bdbdbd;
+  border: 1px solid #757575;
+  border-radius: 2rem;
+}
+
+input[type=range]:focus::-webkit-slider-thumb {
+  border: 2px solid $color-focus;
+}
+
+input[type=range]:focus::-moz-range-thumb {
+  border: 2px solid $color-focus;
+}
+
+input[type=range]:focus::-ms-thumb {
+  border: 2px solid $color-focus;
+}
+
 
 /* topdoc
   name: EOF

--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -508,30 +508,30 @@ input[type=range]::-ms-track {
 input[type=range]::-webkit-slider-thumb {
   -webkit-appearance: none;
   border: 1px solid @input-range-border;
-  height: 2.2rem;
-  border-radius: 1.5rem;
+  height: 45px;
+  border-radius: 50%;
   background: @input-range-handle;
   cursor: pointer;
   margin-top: -.65rem;  
-  width: 2.2rem;
+  width: 45px;
 }
 
 input[type=range]::-moz-range-thumb {
   background: @input-range-handle;
   border: 1px solid @input-range-border;
-  border-radius: 1.5rem;
+  border-radius: 50%;
   cursor: pointer;
-  height: 2.2rem;
-  width: 2.2rem;
+  height: 45px;
+  width: 45px;
 }
 
 input[type=range]::-ms-thumb {
   background: @input-range-handle;
   border: 1px solid @input-range-border;
-  border-radius: 1.5rem;
+  border-radius: 50%;
   cursor: pointer;
-  height: 2.2rem;
-  width: 2.2rem;
+  height: 45px;
+  width: 45px;
 }
 
 input[type=range]::-ms-fill-lower {
@@ -546,16 +546,21 @@ input[type=range]::-ms-fill-upper {
   border-radius: 2rem;
 }
 
-input[type=range]:focus::-webkit-slider-thumb {
-  border: 2px solid @input-border-focus;
-}
+input[type=range]:focus {
+    &::-webkit-slider-thumb {
+        background: @input-inset-selected;
+        border: 2px solid @input-border-focus;
+    }
 
-input[type=range]:focus::-moz-range-thumb {
-  border: 2px solid @input-border-focus;
-}
+    &::-moz-range-thumb {
+        background: @input-inset-selected;
+        border: 2px solid @input-border-focus;
+    }
 
-input[type=range]:focus::-ms-thumb {
-  border: 2px solid @input-border-focus;
+    &::-ms-thumb {
+        background: @input-inset-selected;
+        border: 2px solid @input-border-focus;
+    }
 }
 
 


### PR DESCRIPTION
Adds new range input CSS based on [US Web Design Standards](https://github.com/18F/web-design-standards/blob/0eab0741eb53da738890f6ef063c6d7616eb0e19/assets/_scss/elements/_inputs.scss) and new [Design Manual standards](https://github.com/cfpb/design-manual/issues/346).

Note: this does not implement the value labels which would appear next to the handle (for current selected value) and at the beginning and end of the range element (for the min and max values). These aren't implemented in the US Web Design Standard yet, so we will need to iterate in a future PR to add those. Progress will be tracked in https://github.com/cfpb/cf-forms/issues/44
## Additions
- CSS from US Web Design Standards for range input element
- color variables for range input
- topdocs example of a range element
## Changes
- handle size is larger to match new design standards
- focus colors adapted to match CFPB standards
- `.focus` class for documentation purposes only
- CSS property order updated to match our front end standards
## Review
- @Scotchester 
- @sonnakim 
## Screenshots

<img width="849" alt="screen shot 2015-09-29 at 4 25 44 pm" src="https://cloud.githubusercontent.com/assets/702526/10177188/c83003f4-66c6-11e5-9b70-83b0e44291d5.png">
## Related PRs
- generator-cf color vars 
- capital-framework color vars 
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged
- [ ] Visually tested in supported browsers and devices 
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
