### PR TITLE
add setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# Set script to exit on any errors.
+set -e
+# Note: You must run the script with `./setup.sh`.
+# If you run with `source setup.sh` or `. setup.sh`,
+# and the script encounters an error,
+# the whole terminal window will be forcibly closed.
+
+# Initialize project dependency directories.
+init() {
+  NODE_DIR=node_modules
+  BOWER_DIR=bower_components
+
+  if [ -f .bowerrc ]; then
+    # Get the "directory" line from .bowerrc
+    BOWER_DIR=$(grep "directory" .bowerrc | cut -d '"' -f 4)
+  fi
+
+  echo 'npm components directory:' $NODE_DIR
+  echo 'Bower components directory:' $BOWER_DIR
+}
+
+# Clean project dependencies.
+clean() {
+  # If the node and Bower directories already exist,
+  # clear them so we know we're working with a clean
+  # slate of the dependencies listed in package.json
+  # and bower.json.
+  if [ -d $NODE_DIR ] || [ -d $BOWER_DIR ]; then
+    echo 'Removing project dependency directories...'
+    rm -rf $NODE_DIR
+    rm -rf $BOWER_DIR
+  fi
+
+  echo 'Project dependencies have been removed.'
+}
+
+# Install project dependencies.
+install() {
+  echo 'Installing project dependencies...'
+  npm install
+  bower install --config.interactive=false
+}
+
+# Run tasks to build the project for distribution.
+build() {
+  echo 'Building project...'
+  grunt
+}
+
+init
+clean
+install
+build


### PR DESCRIPTION
Adds `setup.sh` for building the project locally and generating docs + demo files.
## Additions
- `setup.sh` based on 'you-have-the-right' script ([GHE](https://ghe/CFGOV/you-have-the-right/blob/03be16a61e2a9a55127c568aaf01734a710e03e2/setup.sh))
## Changes
- runs default `grunt` command
## Testing
- check this branch out, then from root directory run `sh ./setup.sh`
## Review
- @Scotchester 
- @KimberlyMunoz 
## Checklist
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged
- [ ] Visually tested in supported browsers and devices 
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
