### PR TITLE
Updated for the new heading changes in cf-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 1.5.0 - 2015-11-30
+
+### Changed
+- Converted `.h#()` mixins to `.heading-#()` mixins to match cf-core's current usage
+
+
 ## 1.4.0 - 2015-07-16
 
 ### Additions

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-forms",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Enhanced form styles for Capital Framework.",
   "keywords": ["capital-framework", "capital", "forms", "less"],
   "authors": [

--- a/demo/static/css/main.css
+++ b/demo/static/css/main.css
@@ -763,8 +763,14 @@ input[type="radio"] {
           @base-font-size-px
           @base-line-height-px
           @base-line-height
-          @mobile-max
-          @tablet-min
+          @bp-xs-max
+          @bp-sm-min
+          @bp-sm-max
+          @bp-med-min
+          @bp-med-max
+          @bp-lg-min
+          @bp-lg-max
+          @bp-xl-min
     - name: Colors
       codenotes:
         - |
@@ -777,6 +783,7 @@ input[type="radio"] {
           @link-underline-hover
           @link-text-active
           @link-underline-active
+          @table-border
           @thead-text
           @thead-bg
           @td-bg
@@ -943,13 +950,13 @@ input[type="radio"] {
 */
 .u-visually-hidden {
   position: absolute;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  height: 1px;
   width: 1px;
+  height: 1px;
+  border: 0;
   margin: -1px;
   padding: 0;
-  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
 }
 /* topdoc
   name: Inline block
@@ -1405,7 +1412,12 @@ input[type="radio"] {
   tags:
     - cf-core
 */
-@media only all and (max-width: 37.4375em) {
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
+@media only all and (max-width: 37.5em) {
   .u-hide-on-mobile {
     display: none;
   }
@@ -1413,7 +1425,12 @@ input[type="radio"] {
 .u-show-on-mobile {
   display: none;
 }
-@media only all and (max-width: 37.4375em) {
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
+}
+@media only all and (max-width: 37.5em) {
   .u-show-on-mobile {
     display: block;
   }
@@ -1515,19 +1532,19 @@ small {
         <h1>Example heading element</h1>
         <p class="h1">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h2.
+        - Responsive heading. At small screen sizes, displays as h2.
     - name: Heading level 2
       markup: |
         <h2>Example heading element</h2>
         <p class="h2">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h3.
+        - Responsive heading. At small screen sizes, displays as h3.
     - name: Heading level 3
       markup: |
         <h3>Example heading element</h3>
         <p class="h3">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h4.
+        - Responsive heading. At small screen sizes, displays as h4.
     - name: Heading level 4
       markup: |
         <h4>Example heading element</h4>
@@ -1540,110 +1557,227 @@ small {
       markup: |
         <h6>Example heading element</h6>
         <p class="h6">A non-heading element</p>
-    - name: Subheader
+    - name: Lead paragraph
       markup: |
-        <h1 class="subheader">Example subheader that's kinda long</h1>
-        <p class="subheader">Example subheader that's kinda long</p>
-    - name: Super header
+        <p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      notes:
+        - Responsive. Displays as an h3 on large screens; displays at h4 size (but still Regular weight) on small screens.
+    - name: Display heading (aka "superheading")
       markup: |
-        <h1 class="superheader">Example super header</h1>
-        <p class="superheader">Example super header</p>
+        <h1 class="superheading">Example display heading</h1>
   tags:
     - cf-core
 */
 body {
-  color: #5b3b57;
+  color: #212121;
   font-family: Georgia, "Times New Roman", serif;
   font-size: 100%;
   line-height: 1.375;
 }
 h1,
-.h1,
 h2,
-.h2,
 h3,
-.h3 {
+h4,
+h5,
+h6 {
+  margin-top: 0;
+}
+h1,
+.h1 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
+  margin-bottom: 0.44117647em;
+  font-size: 2.125em;
+  line-height: 1.25;
 }
 h1 em,
 .h1 em,
-h2 em,
-.h2 em,
-h3 em,
-.h3 em,
 h1 i,
-.h1 i,
-h2 i,
-.h2 i,
-h3 i,
-.h3 i {
+.h1 i {
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
 }
 .lt-ie9 h1 em,
 .lt-ie9 .h1 em,
-.lt-ie9 h2 em,
-.lt-ie9 .h2 em,
-.lt-ie9 h3 em,
-.lt-ie9 .h3 em,
 .lt-ie9 h1 i,
-.lt-ie9 .h1 i,
-.lt-ie9 h2 i,
-.lt-ie9 .h2 i,
-.lt-ie9 h3 i,
-.lt-ie9 .h3 i {
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
   font-style: normal !important;
 }
 h1 strong,
 .h1 strong,
-h2 strong,
-.h2 strong,
-h3 strong,
-.h3 strong,
 h1 b,
-.h1 b,
-h2 b,
-.h2 b,
-h3 b,
-.h3 b {
+.h1 b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
 }
 .lt-ie9 h1 strong,
 .lt-ie9 .h1 strong,
-.lt-ie9 h2 strong,
-.lt-ie9 .h2 strong,
-.lt-ie9 h3 strong,
-.lt-ie9 .h3 strong,
 .lt-ie9 h1 b,
-.lt-ie9 .h1 b,
-.lt-ie9 h2 b,
-.lt-ie9 .h2 b,
-.lt-ie9 h3 b,
-.lt-ie9 .h3 b {
+.lt-ie9 .h1 b {
   font-weight: normal !important;
 }
-h1,
-.h1 {
-  margin-top: 0;
-  margin-bottom: 0.47058824em;
-  font-size: 2.125em;
-  line-height: 1.29411765;
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
 }
-@media only all and (max-width: 37.4375em) {
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+p + h1,
+p + .h1,
+ul + h1,
+ul + .h1,
+ol + h1,
+ol + .h1,
+dl + h1,
+dl + .h1,
+figure + h1,
+figure + .h1,
+img + h1,
+img + .h1,
+table + h1,
+table + .h1,
+blockquote + h1,
+blockquote + .h1 {
+  margin-top: 1.76470588em;
+}
+@media only all and (max-width: 37.5em) {
   h1,
   .h1 {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
-    margin-top: 0;
-    margin-bottom: 0.73076923em;
+    margin-bottom: 0.57692308em;
     font-size: 1.625em;
-    line-height: 1.26923077;
+    line-height: 1.25;
   }
   h1 em,
   .h1 em,
@@ -1652,6 +1786,12 @@ h1,
     font-family: Arial, Arial, sans-serif;
     font-style: italic;
     font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
   }
   .lt-ie9 h1 em,
   .lt-ie9 .h1 em,
@@ -1673,17 +1813,11 @@ h1,
   .lt-ie9 .h1 b {
     font-weight: normal !important;
   }
-}
-@media only all and (max-width: 37.4375em) and only all and (max-width: 37.4375em) {
-  h1,
-  .h1 {
-    font-family: Arial, Arial, sans-serif;
-    font-style: normal;
-    font-weight: normal;
-    margin-top: 0;
-    margin-bottom: 0.95454545em;
-    font-size: 1.375em;
-    line-height: 1.27272727;
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
   }
   h1 em,
   .h1 em,
@@ -1692,6 +1826,12 @@ h1,
     font-family: Arial, Arial, sans-serif;
     font-style: italic;
     font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
   }
   .lt-ie9 h1 em,
   .lt-ie9 .h1 em,
@@ -1713,40 +1853,562 @@ h1,
   .lt-ie9 .h1 b {
     font-weight: normal !important;
   }
-}
-@media only all and (max-width: 37.4375em) and only all and (max-width: 37.4375em) and only all and (max-width: 37.4375em) {
-  h1,
-  .h1 {
-    margin-top: 0;
-    margin-bottom: 1.16666667em;
-    font-size: 1.125em;
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
-    font-weight: 500;
-    line-height: 1.22222222;
+    font-weight: bold;
   }
-  .lt-ie9 h1,
-  .lt-ie9 .h1 {
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
     font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
   }
 }
 h2,
 .h2 {
-  margin-top: 0;
-  margin-bottom: 0.73076923em;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.57692308em;
   font-size: 1.625em;
-  line-height: 1.26923077;
+  line-height: 1.25;
 }
-@media only all and (max-width: 37.4375em) {
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+p + h2,
+p + .h2,
+ul + h2,
+ul + .h2,
+ol + h2,
+ol + .h2,
+dl + h2,
+dl + .h2,
+figure + h2,
+figure + .h2,
+img + h2,
+img + .h2,
+table + h2,
+table + .h2,
+blockquote + h2,
+blockquote + .h2 {
+  margin-top: 1.73076923em;
+}
+h1 + h2,
+h1 + .h2,
+.h1 + h2,
+.h1 + .h2,
+h3 + h2,
+h3 + .h2,
+.h3 + h2,
+.h3 + .h2,
+h4 + h2,
+h4 + .h2,
+.h4 + h2,
+.h4 + .h2,
+h5 + h2,
+h5 + .h2,
+.h5 + h2,
+.h5 + .h2,
+h6 + h2,
+h6 + .h2,
+.h6 + h2,
+.h6 + .h2 {
+  margin-top: 1.15384615em;
+}
+@media only all and (max-width: 37.5em) {
   h2,
   .h2 {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
-    margin-top: 0;
-    margin-bottom: 0.95454545em;
+    margin-bottom: 0.68181818em;
     font-size: 1.375em;
-    line-height: 1.27272727;
+    line-height: 1.25;
   }
   h2 em,
   .h2 em,
@@ -1755,6 +2417,12 @@ h2,
     font-family: Arial, Arial, sans-serif;
     font-style: italic;
     font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
   }
   .lt-ie9 h2 em,
   .lt-ie9 .h2 em,
@@ -1776,40 +2444,595 @@ h2,
   .lt-ie9 .h2 b {
     font-weight: normal !important;
   }
-}
-@media only all and (max-width: 37.4375em) and only all and (max-width: 37.4375em) {
-  h2,
-  .h2 {
-    margin-top: 0;
-    margin-bottom: 1.16666667em;
-    font-size: 1.125em;
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
-    font-weight: 500;
-    line-height: 1.22222222;
+    font-weight: bold;
   }
-  .lt-ie9 h2,
-  .lt-ie9 .h2 {
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
     font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
   }
 }
 h3,
 .h3 {
-  margin-top: 0;
-  margin-bottom: 0.95454545em;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.68181818em;
   font-size: 1.375em;
-  line-height: 1.27272727;
+  line-height: 1.25;
 }
-@media only all and (max-width: 37.4375em) {
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+p + h3,
+p + .h3,
+ul + h3,
+ul + .h3,
+ol + h3,
+ol + .h3,
+dl + h3,
+dl + .h3,
+figure + h3,
+figure + .h3,
+img + h3,
+img + .h3,
+table + h3,
+table + .h3,
+blockquote + h3,
+blockquote + .h3,
+h1 + h3,
+h1 + .h3,
+.h1 + h3,
+.h1 + .h3,
+h2 + h3,
+h2 + .h3,
+.h2 + h3,
+.h2 + .h3,
+h4 + h3,
+h4 + .h3,
+.h4 + h3,
+.h4 + .h3,
+h5 + h3,
+h5 + .h3,
+.h5 + h3,
+.h5 + .h3,
+h6 + h3,
+h6 + .h3,
+.h6 + h3,
+.h6 + .h3 {
+  margin-top: 1.36363636em;
+}
+@media only all and (max-width: 37.5em) {
   h3,
   .h3 {
-    margin-top: 0;
-    margin-bottom: 1.16666667em;
-    font-size: 1.125em;
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: 500;
-    line-height: 1.22222222;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
   }
   .lt-ie9 h3,
   .lt-ie9 .h3 {
@@ -1818,97 +3041,421 @@ h3,
 }
 h4,
 .h4 {
-  margin-top: 0;
-  margin-bottom: 1.16666667em;
-  font-size: 1.125em;
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: 500;
-  line-height: 1.22222222;
+  margin-bottom: 0.83333333em;
+  font-size: 1.125em;
+  line-height: 1.25;
 }
 .lt-ie9 h4,
 .lt-ie9 .h4 {
   font-weight: normal !important;
 }
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+p + h4,
+p + .h4,
+ul + h4,
+ul + .h4,
+ol + h4,
+ol + .h4,
+dl + h4,
+dl + .h4,
+figure + h4,
+figure + .h4,
+img + h4,
+img + .h4,
+table + h4,
+table + .h4,
+blockquote + h4,
+blockquote + .h4,
+h1 + h4,
+h1 + .h4,
+.h1 + h4,
+.h1 + .h4,
+h2 + h4,
+h2 + .h4,
+.h2 + h4,
+.h2 + .h4,
+h3 + h4,
+h3 + .h4,
+.h3 + h4,
+.h3 + .h4,
+h5 + h4,
+h5 + .h4,
+.h5 + h4,
+.h5 + .h4,
+h6 + h4,
+h6 + .h4,
+.h6 + h4,
+.h6 + .h4 {
+  margin-top: 1.66666667em;
+}
 h5,
+.h5 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+p + h5,
+p + .h5,
+ul + h5,
+ul + .h5,
+ol + h5,
+ol + .h5,
+dl + h5,
+dl + .h5,
+figure + h5,
+figure + .h5,
+img + h5,
+img + .h5,
+table + h5,
+table + .h5,
+blockquote + h5,
+blockquote + .h5,
+h1 + h5,
+h1 + .h5,
+.h1 + h5,
+.h1 + .h5,
+h2 + h5,
+h2 + .h5,
+.h2 + h5,
+.h2 + .h5,
+h3 + h5,
+h3 + .h5,
+.h3 + h5,
+.h3 + .h5,
+h4 + h5,
+h4 + .h5,
+.h4 + h5,
+.h4 + .h5,
+h6 + h5,
+h6 + .h5,
+.h6 + h5,
+.h6 + .h5 {
+  margin-top: 2.14285714em;
+}
 h6,
-.h5,
 .h6 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+  margin-bottom: 1.25em;
+  font-size: 0.75em;
   letter-spacing: 1px;
+  line-height: 1.25;
   text-transform: uppercase;
 }
-.lt-ie9 h5,
 .lt-ie9 h6,
-.lt-ie9 .h5,
 .lt-ie9 .h6 {
   font-weight: normal !important;
 }
-h5,
-.h5 {
-  margin-top: 0;
-  margin-bottom: 0.35714286em;
-  font-size: 0.875em;
-  line-height: 1.57142857;
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
 }
-h6,
-.h6 {
-  margin-top: 0;
-  margin-bottom: 0.41666667em;
-  font-size: 0.75em;
-  line-height: 1.83333333;
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
 }
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+p + h6,
+p + .h6,
+ul + h6,
+ul + .h6,
+ol + h6,
+ol + .h6,
+dl + h6,
+dl + .h6,
+figure + h6,
+figure + .h6,
+img + h6,
+img + .h6,
+table + h6,
+table + .h6,
+blockquote + h6,
+blockquote + .h6,
+h1 + h6,
+h1 + .h6,
+.h1 + h6,
+.h1 + .h6,
+h2 + h6,
+h2 + .h6,
+.h2 + h6,
+.h2 + .h6,
+h3 + h6,
+h3 + .h6,
+.h3 + h6,
+.h3 + .h6,
+h4 + h6,
+h4 + .h6,
+.h4 + h6,
+.h4 + .h6,
+h5 + h6,
+h5 + .h6,
+.h5 + h6,
+.h5 + .h6 {
+  margin-top: 2.5em;
+}
+.lead-paragraph,
+.subheader,
 .subheader {
-  margin-top: 0;
-  margin-bottom: 1.16666667em;
-  font-size: 1.125em;
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
-  line-height: 1.22222222;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+  margin-top: 1.36363636em;
+  margin-bottom: 0.83333333em;
 }
-.subheader em,
-.subheader i {
+.lead-paragraph em,
+.lead-paragraph i {
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
 }
-.lt-ie9 .subheader em,
-.lt-ie9 .subheader i {
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
   font-style: normal !important;
 }
-.subheader strong,
-.subheader b {
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
 }
-.lt-ie9 .subheader strong,
-.lt-ie9 .subheader b {
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
   font-weight: normal !important;
 }
-.superheader {
-  margin-bottom: 0.1875em;
-  font-size: 3em;
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+.superheading,
+.superheader,
+.superheader {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.41666667em;
+  font-size: 3em;
   line-height: 1.25;
 }
-.lt-ie9 .superheader {
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
   font-weight: normal !important;
 }
 /* topdoc
-  name: Margins
+  name: Body copy element vertical margins
   family: cf-core
   patterns:
     - name: Consistent vertical margins
       notes:
-        - "Assumes that the font size of each of these items remains the default."
+        - Applies 15px bottom margin to all p, ul, ol, dl, figure, table, and blockquote elements.
+        - Applies -5px top margin to lists following paragraphs to reduce margin between them to 10px.
+        - Applies 8px bottom margin to list items that are not within a nav element.
+        - Assumes that the font size of each of these items remains the default.
       markup: |
         <p>Paragraph margin example</p>
+        <p>Paragraph margin example</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
         <p>Paragraph margin example</p>
   tags:
     - cf-core
@@ -1917,10 +3464,21 @@ p,
 ul,
 ol,
 dl,
+figure,
 table,
-figure {
+blockquote {
   margin-top: 0;
-  margin-bottom: 1.25em;
+  margin-bottom: 0.9375em;
+}
+p + ul,
+p + ol {
+  margin-top: -0.3125em;
+}
+:not(nav) li {
+  margin-bottom: 0.5em;
+}
+.lt-ie9 nav li {
+  margin-bottom: 0;
 }
 /* topdoc
   name: Default link
@@ -1950,20 +3508,20 @@ figure {
 a {
   border-width: 0;
   border-style: dotted;
-  border-color: #c7336e;
-  color: #c7336e;
+  border-color: #0071bc;
+  color: #0071bc;
   text-decoration: none;
 }
 a:visited,
 a.visited {
-  border-color: #cf447c;
-  color: #cf447c;
+  border-color: #4c2c92;
+  color: #4c2c92;
 }
 a:hover,
 a.hover {
   border-style: solid;
-  border-color: #9e2958;
-  color: #9e2958;
+  border-color: #205493;
+  color: #205493;
 }
 a:focus,
 a.focus {
@@ -1973,8 +3531,8 @@ a.focus {
 a:active,
 a.active {
   border-style: solid;
-  border-color: #8a234c;
-  color: #8a234c;
+  border-color: #046b99;
+  color: #046b99;
 }
 /* topdoc
   name: Underlined links
@@ -2054,16 +3612,32 @@ nav a {
   patterns:
     - name: Unordered list
       markup: |
+        <p>Paragraph example for visual reference</p>
         <ul>
-            <li>List item</li>
-            <li>List item</li>
-            <li>List item</li>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
         </ul>
+    - name: Ordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ol>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ol>
   tags:
     - cf-core
 */
 ul {
+  padding-left: 2em;
   list-style: square;
+}
+ol {
+  padding-left: 1.9375em;
+}
+ol > li {
+  padding-left: 0.0625em;
 }
 /* topdoc
   name: Tables
@@ -2081,52 +3655,22 @@ ul {
             </thead>
             <tbody>
                 <tr>
-                    <th>Row 1 header</th>
+                    <td>Row 1, column 1</td>
                     <td>Row 1, column 2</td>
                     <td>Row 1, column 3</td>
                 </tr>
                 <tr>
-                    <th>Row 2 header</th>
+                    <td>Row 2, column 1</td>
                     <td>Row 2, column 2</td>
                     <td>Row 2, column 3</td>
                 </tr>
                 <tr>
-                    <th>Row 3 header</th>
+                    <td>Row 3, column 1</td>
                     <td>Row 3, column 2</td>
                     <td>Row 3, column 3</td>
                 </tr>
             </tbody>
         </table>
-    - name: Compact table
-      markup: |
-        <table class="compact-table">
-            <thead>
-                <tr>
-                    <th>Column 1 header</th>
-                    <th>Column 2 header</th>
-                    <th>Column 3 header</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <th>Row 1 header</th>
-                    <td>Row 1, column 2</td>
-                    <td>Row 1, column 3</td>
-                </tr>
-                <tr>
-                    <th>Row 2 header</th>
-                    <td>Row 2, column 2</td>
-                    <td>Row 2, column 3</td>
-                </tr>
-                <tr>
-                    <th>Row 3 header</th>
-                    <td>Row 3, column 2</td>
-                    <td>Row 3, column 3</td>
-                </tr>
-            </tbody>
-        </table>
-      notes:
-        - Reduces cell padding to 10px.
   tags:
     - cf-core
 */
@@ -2145,6 +3689,10 @@ table i {
 .lt-ie9 table i {
   font-style: normal !important;
 }
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
 table strong,
 table b {
   font-family: Arial, Arial, sans-serif;
@@ -2155,23 +3703,166 @@ table b {
 .lt-ie9 table b {
   font-weight: normal !important;
 }
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
 th,
 td {
-  padding: 0.75em 0.9375em;
-  background: #eee4ed;
+  padding: 0.625em;
 }
 thead th,
 thead td {
-  color: #ffffff;
-  background: #5b3b57;
+  color: #212121;
+  background: #f1f1f1;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
-tbody > tr:nth-child(odd) > th,
-tbody > tr:nth-child(odd) > td {
-  background: #f4edf3;
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
 }
-.compact-table th,
-.compact-table td {
-  padding: 0.4375em 0.625em;
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+thead,
+tbody tr {
+  border-bottom: 1px solid #5b616b;
 }
 th {
   font-family: Arial, Arial, sans-serif;
@@ -2180,6 +3871,70 @@ th {
   text-align: left;
 }
 .lt-ie9 th {
+  font-weight: normal !important;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
+}
+tbody th {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
   font-weight: normal !important;
 }
 /* topdoc
@@ -2208,72 +3963,19 @@ th {
     - cf-core
 */
 blockquote {
-  margin: 1.25em;
+  margin-right: 0.9375em;
+  margin-left: 0.9375em;
 }
-@media only all and (min-width: 37.5em) {
+@media only all and (min-width: 37.5625em) {
   blockquote {
-    margin: 1.75em 2.5em;
+    margin-right: 1.875em;
+    margin-left: 1.875em;
   }
 }
-/* topdoc
-    name: Fieldsets
-    family: cf-core
-    notes:
-      - "Visit https://github.com/cfpb/cf-forms for advanced fieldset patterns."
-    patterns:
-    - name: Default fieldset legend
-      markup: |
-        <fieldset>
-            <legend>Fieldset legend</legend>
-            <label for="name">
-                Label
-            </label>
-            <input type="text" id="name" value="" placeholder="Placeholder text">
-        </fieldset>
-    tags:
-    - cf-core
-*/
-legend {
-  font-family: Arial, Arial, sans-serif;
-  font-style: normal;
-  font-weight: normal;
-  margin-top: 0;
-  margin-bottom: 0.95454545em;
-  font-size: 1.375em;
-  line-height: 1.27272727;
-}
-legend em,
-legend i {
-  font-family: Arial, Arial, sans-serif;
-  font-style: italic;
-  font-weight: normal;
-}
-.lt-ie9 legend em,
-.lt-ie9 legend i {
-  font-style: normal !important;
-}
-legend strong,
-legend b {
-  font-family: Arial, Arial, sans-serif;
-  font-style: normal;
-  font-weight: bold;
-}
-.lt-ie9 legend strong,
-.lt-ie9 legend b {
-  font-weight: normal !important;
-}
-@media only all and (max-width: 37.4375em) {
-  legend {
-    margin-top: 0;
-    margin-bottom: 1.16666667em;
-    font-size: 1.125em;
-    font-family: Arial, Arial, sans-serif;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 1.22222222;
-  }
-  .lt-ie9 legend {
-    font-weight: normal !important;
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
   }
 }
 /* topdoc
@@ -2315,11 +4017,47 @@ label i {
 .lt-ie9 label i {
   font-style: normal !important;
 }
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
 label strong,
 label b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
 }
 .lt-ie9 label strong,
 .lt-ie9 label b {
@@ -2408,7 +4146,7 @@ select[multiple] {
   font-family: Arial, sans-serif;
   font-size: 1em;
   background: #ffffff;
-  border: 1px solid #5b3b57;
+  border: 1px solid #5b616b;
   border-radius: 0;
   vertical-align: top;
   -webkit-appearance: none;
@@ -2433,8 +4171,8 @@ textarea:focus,
 textarea.focus,
 select[multiple]:focus,
 select[multiple].focus {
-  border: 1px solid #c7336e;
-  outline: 1px solid #c7336e;
+  border: 1px solid #3e94cf;
+  outline: 1px solid #3e94cf;
   outline-offset: 0;
   -webkit-box-shadow: none;
   box-shadow: none;
@@ -2488,7 +4226,3497 @@ figure img {
   vertical-align: middle;
 }
 .figure__bordered img {
-  border: 1px solid #5b3b57;
+  border: 1px solid #d6d7d9;
+}
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Core Less file
+   ========================================================================== */
+/* ==========================================================================
+   Capital Framework
+   Less variables
+   ========================================================================== */
+/* topdoc
+  name: Theme variables
+  family: cf-core
+  notes:
+    - "The following color and sizing variables are exposed, allowing you to
+       easily override them before compiling."
+  patterns:
+    - name: Sizing
+      codenotes:
+        - |
+          @base-font-size-px
+          @base-line-height-px
+          @base-line-height
+          @bp-xs-max
+          @bp-sm-min
+          @bp-sm-max
+          @bp-med-min
+          @bp-med-max
+          @bp-lg-min
+          @bp-lg-max
+          @bp-xl-min
+    - name: Colors
+      codenotes:
+        - |
+          @text
+          @link-text
+          @link-underline
+          @link-text-visited
+          @link-underline-visited
+          @link-text-hover
+          @link-underline-hover
+          @link-text-active
+          @link-underline-active
+          @table-border
+          @thead-text
+          @thead-bg
+          @td-bg
+          @td-bg-alt
+          @input-bg
+          @input-border
+          @input-border-focus
+          @input-placeholder
+          @figure__bordered
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Media queries
+   ========================================================================== */
+/* topdoc
+  name: Media query mixins
+  family: cf-core
+  notes:
+    - "These mixins allow us to write consistent media queries using pixel
+      values, which are easier to remember. The mixins handle converting the
+      pixels into em's."
+  patterns:
+    - name: "min-width/max-width media queries"
+      codenotes:
+        - ".respond-to-min(@bp, @rules)"
+        - ".respond-to-max(@bp, @rules)"
+      notes:
+        - "@bp: the breakpoint size in pixels. It will get converted into em's."
+        - "@rules: a CSS or Less ruleset. Note that it can contain the full set
+          of Less features."
+    - name: "min-width/max-width media query usage"
+      codenotes:
+        - |
+            .respond-to-min(768px, {
+                .title {
+                    font-size: 2em;
+                }
+            });
+
+            Compiles to:
+
+            @media only all and (min-width: 48em) {
+                .title {
+                    font-size: 2em;
+                }
+            }
+    - name: "min-width/max-width media query range"
+      codenotes:
+        - ".respond-to-range(@bp1, @bp2, @rules)"
+      notes:
+        - "@bp1: the min-width breakpoint size in pixels.
+          It will get converted into em's."
+        - "@bp2: the max-width breakpoint size in pixels.
+          It will get converted into em's."
+        - "@rules: a CSS or Less ruleset. Note that it can contain the full set
+          of Less features."
+    - name: "min-width/max-width media query range usage"
+      codenotes:
+        - |
+            .respond-to-range(320px, 768px, {
+                .title {
+                    font-size: 2em;
+                }
+            });
+
+            Compiles to:
+
+            @media only all and (min-width: 20em) and (max-width: 48em) {
+                .title {
+                    font-size: 2em;
+                }
+            }
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Utilities
+   ========================================================================== */
+/* topdoc
+  name: JS-only
+  family: cf-core
+  patterns:
+    - name: Setup
+      codenotes:
+        - <html class="no-js">
+        - |
+            <script>
+                // Confirm availability of JS and remove no-js class from html
+                var docElement = document.documentElement;
+                docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
+            </script>
+      notes:
+        - "First add the .no-js class to the HTML element."
+        - "Then add the script to your HEAD which removes the .no-js class when
+           JS is available."
+    - name: Utility class
+      codenotes:
+        - .u-js-only;
+      notes:
+        - "Hide stuff when JavaScript isn't available. Depends on having a small
+           script in the HEAD of your HTML document that removes a .no-js class."
+  tags:
+    - cf-core
+*/
+.no-js .u-js-only {
+  display: none !important;
+}
+/* topdoc
+  name: Clearfix
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <div class="u-clearfix">
+            <div style="float:left; width:100%; height:60px; background:black;"></div>
+        </div>
+      codenotes:
+        - .u-clearfix;
+      notes:
+        - "Use this class to clear floats. For example, without .u-clearfix the
+           black box would spill into the markup section."
+        - "More information: http://css-tricks.com/snippets/css/clear-fix/"
+  tags:
+    - cf-core
+*/
+.u-clearfix:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.lt-ie8 .u-clearfix {
+  zoom: 1;
+}
+/* topdoc
+  name: Visually hidden
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <h1>
+            <a href="#">
+                <span class="cf-icon cf-icon-twitter-square"></span>
+                <span class="u-visually-hidden">Share on Twitter</span>
+            </a>
+        </h1>
+      codenotes:
+        - .u-visually-hidden;
+      notes:
+        - "Use this class to hide something from view while keeping it
+          accessible to screen readers."
+  tags:
+    - cf-core
+*/
+.u-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  border: 0;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+/* topdoc
+  name: Inline block
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - .u-inline-block;
+      notes:
+        - "Also adds a .lt-ie8 class to hack inline-block for IE 7 and below."
+  tags:
+    - cf-core
+*/
+.u-inline-block {
+  display: inline-block;
+}
+.lt-ie8 .u-inline-block {
+  display: inline;
+}
+/* topdoc
+  name: Floating right
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - .u-right;
+      notes:
+        - "IE7 float: right drop bug fixes:"
+        - "1. If the float: right follows an element in the html structure that
+          should be to its left (and not above it), then that preceding
+          element(s) must be float: left.
+          http://stackoverflow.com/questions/10981767/clean-css-fix-of-ie7s-float-right-drop-bug#answer-11437688"
+        - "2. Simply change the markup order so that the element floating right
+          comes before the element to its left."
+  tags:
+    - cf-core
+*/
+.u-right {
+  float: right;
+}
+/* topdoc
+  name: Break word
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <div style="width: 100px;">
+            This link should break:
+            <br>
+            <a class="u-break-word" href="#">
+                something@something.com
+            </a>
+            <br>
+            <br>
+            This link should not:
+            <br>
+            <a href="#">
+                something@something.com
+            </a>
+        </div>
+      codenotes:
+        - .u-break-word
+      notes:
+        - "Use this on elements where you need the words to break when confined
+           to small containers."
+        - "This only works in IE8 when the element with the .u-break-word class
+           has layout. See <http://stackoverflow.com/questions/3997223/word-wrapbreak-word-not-working-in-ie8>
+           for more information."
+  tags:
+    - cf-core
+*/
+.u-break-word {
+  word-break: break-all;
+}
+/* topdoc
+  name: Align with button
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - ".u-align-with-btn(@font-size: @base-font-size-px);"
+      notes:
+        - "Adds top padding (among other things) to help alignment with buttons."
+        - "If you pass no arguments then the padding will be calculated using
+          @base-font-size-px."
+        - "Pass one argument to use a custom font size to calculate the top
+          padding."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Flexible proportional containers
+  family: cf-core
+  notes:
+    - "Utilizes intrinsic ratios to create a flexible container that retains its
+      aspect ratio. When image tags scale they retain their aspect ratio, but if
+      you need a flexible video you will need to use this mixin."
+    - "You can read more about intrinsic rations here:
+      http://alistapart.com/article/creating-intrinsic-ratios-for-video"
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="u-flexible-container">
+            <video
+              class="u-flexible-container_inner"
+              style="background:#75787B;"
+              controls>
+            </video>
+        </div>
+      notes:
+        - "Defaults to a 16:19 ratio."
+        - "Original mixin credit: https://gist.github.com/craigmdennis/6655047"
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container
+            .u-flexible-container_inner
+    - name: Background image examples
+      markup: |
+        <div class="u-flexible-container"
+             style="
+               background-image:url(http://placekitten.com/700/394);
+               background-position: center center;
+             ">
+        </div>
+        <div class="u-flexible-container"
+             style="
+               background-image:url(http://placekitten.com/700/394);
+               background-position: center center;
+               background-size: cover;
+             ">
+        </div>
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container
+      notes:
+        - "If you're not using the video or object elements and all you need is
+          a proportionally cropped or scaling background image with a fluid
+          container then you can leave out u-flexible-container_inner."
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+    - name: 4-3 modifier
+      markup: |
+        <div class="u-flexible-container u-flexible-container__4-3">
+            <video
+              class="u-flexible-container_inner"
+              style="background:#75787B;"
+              controls>
+            </video>
+        </div>
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container.u-flexible-container__4-3
+            .u-flexible-container_inner
+      notes:
+        - "Create your own aspect ratios by using this modifier as an example."
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+  tags:
+    - cf-core
+*/
+.u-flexible-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+}
+.u-flexible-container_inner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.u-flexible-container__4-3 {
+  position: relative;
+  padding-bottom: 75%;
+  height: 0;
+}
+/* topdoc
+  name: Link mixins
+  family: cf-core
+  patterns:
+    - codenotes:
+        - .u-link__colors();
+      notes:
+        - "Pass this mixin no arguments to color your link states with the
+          following defaults: :link (default state) pacific, :hover pacific-50,
+          :focus: pacific, :visited teal, :active navy."
+    - codenotes:
+        - .u-link__colors(@c);
+      notes:
+        - "Pass this mixin one color to be used on all of the following
+          states of your link; :link (default state), :visited, :hover, :focus,
+          :active."
+    - codenotes:
+        - .u-link__colors(@c, @h);
+      notes:
+        - "Pass this mixin two colors to use the first color for the :link,
+          :visited, and :active states, and the second color for the :hover and
+          :focus states."
+    - codenotes:
+        - .u-link__colors(@c, @v, @h, @f, @a);
+      notes:
+        - "Pass this mixin five colors in 'love/hate' mnemonic order to color
+          :link, :visited, :hover, :focus, and :active states respectively."
+        - "Even though this mixin is basically the same as
+          .u-link__colors-base(@c, @v, @h, @f, @a); we encourage you to use
+          .u-link__colors(@c, @v, @h, @f, @a) to promote consistency."
+    - codenotes:
+        - .u-link__colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba);
+      notes:
+        - "Allows you to color text and the borders separately."
+        - "The first five colors in 'love/hate' mnemonic order will color text
+          for the :link, :visited, :hover, :focus, and :active states
+          respectively. The last five colors in 'love/hate' mnemonic order will
+          color the borders for the :link, :visited, :hover, :focus, and :active
+          states respectively."
+        - "Even though this mixin is basically the same as
+          .u-link__colors-base(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba); we
+          encourage you to use .u-link__colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba)
+          to promote consistency."
+    - codenotes:
+        - .u-link__colors-base(@c, @v, @h, @f, @a);
+      notes:
+        - "This is the base mixin that all .u-link__colors() mixins use. Please
+          refrain from using this mixin directly in order to promote a
+          consistent use of mixin names for coloring links throughout this
+          project. Remember that if you need to set colors for all states of a
+          link you should use .u-link__colors(@c, @v, @h, @f, @a)."
+    - codenotes:
+        - .u-link__border();
+      notes:
+        - "Forces the default bottom border on the :link and :hover states."
+    - codenotes:
+        - .u-link__no-border();
+      notes:
+        - "Turn off the default bottom border on the :link and :hover states."
+    - codenotes:
+        - .u-link__hover-border();
+      notes:
+        - "Turn off the default bottom border on the :link state and force a
+          bottom border on the :hover state."
+    - codenotes:
+        - .u-link-child__hover();
+      notes:
+        - "When a link has child elements you may want only certain children to
+          change color when the parent link is hovered.
+          Pass no arguments to this mixin to color the child element pacific
+          when the parent link is hovered."
+    - codenotes:
+        - .u-link-child__hover(@c);
+      notes:
+        - "Pass this mixin one color to color the child element when the parent
+          link is hovered."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Margin utilities
+  family: cf-core
+  patterns:
+    - name: Utility classes
+      codenotes:
+        - .u-m<p><#>;
+      notes:
+        - "Replace <p> with the first letter of the position ('t' for top or 'b'
+           for bottom) and <#> with the pixel value of the margin you want."
+        - "Available values: 0, 5, 10, 15, 20, 30, 45, 60."
+  tags:
+    - cf-core
+*/
+.u-mt0 {
+  margin-top: 0 !important;
+}
+.u-mb0 {
+  margin-bottom: 0 !important;
+}
+.u-mt5 {
+  margin-top: 5px !important;
+}
+.u-mb5 {
+  margin-bottom: 5px !important;
+}
+.u-mt10 {
+  margin-top: 10px !important;
+}
+.u-mb10 {
+  margin-bottom: 10px !important;
+}
+.u-mt15 {
+  margin-top: 15px !important;
+}
+.u-mb15 {
+  margin-bottom: 15px !important;
+}
+.u-mt20 {
+  margin-top: 20px !important;
+}
+.u-mb20 {
+  margin-bottom: 20px !important;
+}
+.u-mt30 {
+  margin-top: 30px !important;
+}
+.u-mb30 {
+  margin-bottom: 30px !important;
+}
+.u-mt45 {
+  margin-top: 45px !important;
+}
+.u-mb45 {
+  margin-bottom: 45px !important;
+}
+.u-mt60 {
+  margin-top: 60px !important;
+}
+.u-mb60 {
+  margin-bottom: 60px !important;
+}
+/* topdoc
+  name: Width utilities
+  family: cf-core
+  patterns:
+    - name: Percent-based
+      markup: |
+        <div class="u-w100pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w100pct</code>
+        </div>
+        <div class="u-w90pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w90pct</code>
+        </div>
+        <div class="u-w80pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w80pct</code>
+        </div>
+        <div class="u-w70pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w70pct</code>
+        </div>
+        <div class="u-w60pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w60pct</code>
+        </div>
+        <div class="u-w50pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w50pct</code>
+        </div>
+        <div class="u-w40pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w40pct</code>
+        </div>
+        <div class="u-w30pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w30pct</code>
+        </div>
+        <div class="u-w20pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w20pct</code>
+        </div>
+        <div class="u-w10pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w10pct</code>
+        </div>
+        <div class="u-w75pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w75pct</code>
+        </div>
+        <div class="u-w25pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w25pct</code>
+        </div>
+        <div class="u-w66pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w66pct</code>
+        </div>
+        <div class="u-w33pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w33pct</code>
+        </div>
+      notes:
+        - "Inline styles are for demonstration purposes only, please don't use
+           them."
+  tags:
+    - cf-core
+*/
+.u-w100pct {
+  width: 100%;
+}
+.u-w90pct {
+  width: 90%;
+}
+.u-w80pct {
+  width: 80%;
+}
+.u-w70pct {
+  width: 70%;
+}
+.u-w60pct {
+  width: 60%;
+}
+.u-w50pct {
+  width: 50%;
+}
+.u-w40pct {
+  width: 40%;
+}
+.u-w30pct {
+  width: 30%;
+}
+.u-w20pct {
+  width: 20%;
+}
+.u-w10pct {
+  width: 10%;
+}
+.u-w75pct {
+  width: 75%;
+}
+.u-w25pct {
+  width: 25%;
+}
+.u-w66pct {
+  width: 66.66666667%;
+}
+.u-w33pct {
+  width: 33.33333333%;
+}
+/* topdoc
+  name: Width-specific display
+  family: cf-core
+  patterns:
+    - name: Show on mobile
+      markup: |
+        <section>
+            <p>The the text in the box below is visible only at widths less than 600px</p>
+            <div style="border: 1px solid black; height: 22px; padding: 5px;">
+                <p class="u-show-on-mobile">Visible on mobile</p>
+            </div>
+        </section>
+      codenotes:
+        - ".u-show-on-mobile"
+        - "Uses 'display:block' to toggle display. Would need to be extended
+          for inline use cases."
+      notes:
+        - "Displays an element only at mobile widths."
+    - name: Hide on mobile
+      markup: |
+        <section>
+            <p>The text in the box below is hidden at widths less than 600px</p>
+            <div style="border: 1px solid black; height: 22px; padding: 5px;">
+                <p class="u-hide-on-mobile">Hidden on mobile</p>
+            </div>
+        </section>
+      codenotes:
+        - ".u-hide-on-mobile"
+      notes:
+        - "Hides an element at mobile widths"
+  tags:
+    - cf-core
+*/
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
+.u-show-on-mobile {
+  display: none;
+}
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
+}
+/* topdoc
+  name: Small text utility
+  family: cf-core
+  patterns:
+    - name: .u-small-text (utility class)
+      markup: |
+        Lorem ipsum<br>
+        <span class="u-small-text">dolor sit amet</span>
+      codenotes:
+        - ".u-small-text"
+      notes:
+        - "14px text."
+        - "The utility class should only be used when the default text size is
+           16px. For example you wouldn't want to use the class inside of an
+           `h1` because the `font-size` in the `h1` will make `.u-small-text`
+           bigger than it should be. See the docs for the `.u-small-text()`
+           mixin."
+    - name: .u-small-text() (Less mixin)
+      codenotes:
+        - ".u-small-text(@context)"
+        - |
+          // Mixin usage:
+          .example {
+            font-size: unit(20px / @base-font-size-px, em);
+            small {
+              .u-small-text(20px);
+            }
+          }
+          // Compiles to:
+          .example {
+            font-size: 1.25em;
+          }
+          .example small {
+            font-size: 0.7em;
+          }
+      notes:
+        - "This mixin enables you to easily create consistent small text by
+           passing the context `font-size`."
+  tags:
+    - cf-core
+*/
+.u-small-text {
+  font-size: 0.875em;
+}
+small {
+  font-size: 0.875em;
+}
+/* topdoc
+    name: EOF
+    eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Base styles
+   ========================================================================== */
+/* topdoc
+  name: Webfonts
+  family: cf-core
+  patterns:
+    - name: Webfont mixins and variables
+      codenotes:
+        - ".webfont-regular()"
+        - ".webfont-italic()"
+        - ".webfont-medium()"
+        - ".webfont-demi()"
+      notes:
+        - "Use these mixins to easily add the your preferred font family to your
+          elements."
+        - "To use your own fonts in the webfont mixins, set your own font with the
+          @webfont-regular/italic/medium/demi variables."
+        - "To avoid faux bold and italics,
+          you must use the font family name for that particular style.
+          For example, when defining an italic in Helvetica
+          you need to use the Helvetica Italic font family.
+          Use the mixins when setting bold or italic text as they also
+          set the appropriate font-weight and font-style."
+        - "These mixins also add the appropriate .lt-ie9 overrides.
+          .lt-ie9 overrides are necessary to override font-style and font-weight
+          each time the webfont is used. These overrides are built into the webfont
+          mixins so you get them automatically. Note that this requires you to
+          use conditional classes on the <html> element:
+          https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md#conditional-html-classes."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Type hierarchy
+  family: cf-core
+  patterns:
+    - name: Default body type
+      markup: |
+        <p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    - name: Heading level 1
+      markup: |
+        <h1>Example heading element</h1>
+        <p class="h1">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h2.
+    - name: Heading level 2
+      markup: |
+        <h2>Example heading element</h2>
+        <p class="h2">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h3.
+    - name: Heading level 3
+      markup: |
+        <h3>Example heading element</h3>
+        <p class="h3">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h4.
+    - name: Heading level 4
+      markup: |
+        <h4>Example heading element</h4>
+        <p class="h4">A non-heading element</p>
+    - name: Heading level 5
+      markup: |
+        <h5>Example heading element</h5>
+        <p class="h5">A non-heading element</p>
+    - name: Heading level 6
+      markup: |
+        <h6>Example heading element</h6>
+        <p class="h6">A non-heading element</p>
+    - name: Lead paragraph
+      markup: |
+        <p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      notes:
+        - Responsive. Displays as an h3 on large screens; displays at h4 size (but still Regular weight) on small screens.
+    - name: Display heading (aka "superheading")
+      markup: |
+        <h1 class="superheading">Example display heading</h1>
+  tags:
+    - cf-core
+*/
+body {
+  color: #212121;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 100%;
+  line-height: 1.375;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 0;
+}
+h1,
+.h1 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.44117647em;
+  font-size: 2.125em;
+  line-height: 1.25;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+p + h1,
+p + .h1,
+ul + h1,
+ul + .h1,
+ol + h1,
+ol + .h1,
+dl + h1,
+dl + .h1,
+figure + h1,
+figure + .h1,
+img + h1,
+img + .h1,
+table + h1,
+table + .h1,
+blockquote + h1,
+blockquote + .h1 {
+  margin-top: 1.76470588em;
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+h2,
+.h2 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.57692308em;
+  font-size: 1.625em;
+  line-height: 1.25;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+p + h2,
+p + .h2,
+ul + h2,
+ul + .h2,
+ol + h2,
+ol + .h2,
+dl + h2,
+dl + .h2,
+figure + h2,
+figure + .h2,
+img + h2,
+img + .h2,
+table + h2,
+table + .h2,
+blockquote + h2,
+blockquote + .h2 {
+  margin-top: 1.73076923em;
+}
+h1 + h2,
+h1 + .h2,
+.h1 + h2,
+.h1 + .h2,
+h3 + h2,
+h3 + .h2,
+.h3 + h2,
+.h3 + .h2,
+h4 + h2,
+h4 + .h2,
+.h4 + h2,
+.h4 + .h2,
+h5 + h2,
+h5 + .h2,
+.h5 + h2,
+.h5 + .h2,
+h6 + h2,
+h6 + .h2,
+.h6 + h2,
+.h6 + .h2 {
+  margin-top: 1.15384615em;
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+h3,
+.h3 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+p + h3,
+p + .h3,
+ul + h3,
+ul + .h3,
+ol + h3,
+ol + .h3,
+dl + h3,
+dl + .h3,
+figure + h3,
+figure + .h3,
+img + h3,
+img + .h3,
+table + h3,
+table + .h3,
+blockquote + h3,
+blockquote + .h3,
+h1 + h3,
+h1 + .h3,
+.h1 + h3,
+.h1 + .h3,
+h2 + h3,
+h2 + .h3,
+.h2 + h3,
+.h2 + .h3,
+h4 + h3,
+h4 + .h3,
+.h4 + h3,
+.h4 + .h3,
+h5 + h3,
+h5 + .h3,
+.h5 + h3,
+.h5 + .h3,
+h6 + h3,
+h6 + .h3,
+.h6 + h3,
+.h6 + .h3 {
+  margin-top: 1.36363636em;
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+h4,
+.h4 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  margin-bottom: 0.83333333em;
+  font-size: 1.125em;
+  line-height: 1.25;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+p + h4,
+p + .h4,
+ul + h4,
+ul + .h4,
+ol + h4,
+ol + .h4,
+dl + h4,
+dl + .h4,
+figure + h4,
+figure + .h4,
+img + h4,
+img + .h4,
+table + h4,
+table + .h4,
+blockquote + h4,
+blockquote + .h4,
+h1 + h4,
+h1 + .h4,
+.h1 + h4,
+.h1 + .h4,
+h2 + h4,
+h2 + .h4,
+.h2 + h4,
+.h2 + .h4,
+h3 + h4,
+h3 + .h4,
+.h3 + h4,
+.h3 + .h4,
+h5 + h4,
+h5 + .h4,
+.h5 + h4,
+.h5 + .h4,
+h6 + h4,
+h6 + .h4,
+.h6 + h4,
+.h6 + .h4 {
+  margin-top: 1.66666667em;
+}
+h5,
+.h5 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+p + h5,
+p + .h5,
+ul + h5,
+ul + .h5,
+ol + h5,
+ol + .h5,
+dl + h5,
+dl + .h5,
+figure + h5,
+figure + .h5,
+img + h5,
+img + .h5,
+table + h5,
+table + .h5,
+blockquote + h5,
+blockquote + .h5,
+h1 + h5,
+h1 + .h5,
+.h1 + h5,
+.h1 + .h5,
+h2 + h5,
+h2 + .h5,
+.h2 + h5,
+.h2 + .h5,
+h3 + h5,
+h3 + .h5,
+.h3 + h5,
+.h3 + .h5,
+h4 + h5,
+h4 + .h5,
+.h4 + h5,
+.h4 + .h5,
+h6 + h5,
+h6 + .h5,
+.h6 + h5,
+.h6 + .h5 {
+  margin-top: 2.14285714em;
+}
+h6,
+.h6 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.25em;
+  font-size: 0.75em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+p + h6,
+p + .h6,
+ul + h6,
+ul + .h6,
+ol + h6,
+ol + .h6,
+dl + h6,
+dl + .h6,
+figure + h6,
+figure + .h6,
+img + h6,
+img + .h6,
+table + h6,
+table + .h6,
+blockquote + h6,
+blockquote + .h6,
+h1 + h6,
+h1 + .h6,
+.h1 + h6,
+.h1 + .h6,
+h2 + h6,
+h2 + .h6,
+.h2 + h6,
+.h2 + .h6,
+h3 + h6,
+h3 + .h6,
+.h3 + h6,
+.h3 + .h6,
+h4 + h6,
+h4 + .h6,
+.h4 + h6,
+.h4 + .h6,
+h5 + h6,
+h5 + .h6,
+.h5 + h6,
+.h5 + .h6 {
+  margin-top: 2.5em;
+}
+.lead-paragraph,
+.subheader,
+.subheader {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+  margin-top: 1.36363636em;
+  margin-bottom: 0.83333333em;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+.superheading,
+.superheader,
+.superheader {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.41666667em;
+  font-size: 3em;
+  line-height: 1.25;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+/* topdoc
+  name: Body copy element vertical margins
+  family: cf-core
+  patterns:
+    - name: Consistent vertical margins
+      notes:
+        - Applies 15px bottom margin to all p, ul, ol, dl, figure, table, and blockquote elements.
+        - Applies -5px top margin to lists following paragraphs to reduce margin between them to 10px.
+        - Applies 8px bottom margin to list items that are not within a nav element.
+        - Assumes that the font size of each of these items remains the default.
+      markup: |
+        <p>Paragraph margin example</p>
+        <p>Paragraph margin example</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
+        <p>Paragraph margin example</p>
+  tags:
+    - cf-core
+*/
+p,
+ul,
+ol,
+dl,
+figure,
+table,
+blockquote {
+  margin-top: 0;
+  margin-bottom: 0.9375em;
+}
+p + ul,
+p + ol {
+  margin-top: -0.3125em;
+}
+:not(nav) li {
+  margin-bottom: 0.5em;
+}
+.lt-ie9 nav li {
+  margin-bottom: 0;
+}
+/* topdoc
+  name: Default link
+  notes:
+    - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not
+      be used in production."
+  family: cf-core
+  patterns:
+    - name: Default state
+      markup: |
+        <a href="#">Default link style</a>
+    - name: Visited state
+      markup: |
+        <a href="#" class="visited">Visited link style</a>
+    - name: Hovered state
+      markup: |
+        <a href="#" class="hover">Hovered link style</a>
+    - name: Focused state
+      markup: |
+        <a href="#" class="focus">Focused link style</a>
+    - name: Active state
+      markup: |
+        <a href="#" class="active">Active link style</a>
+  tags:
+    - cf-core
+*/
+a {
+  border-width: 0;
+  border-style: dotted;
+  border-color: #0071bc;
+  color: #0071bc;
+  text-decoration: none;
+}
+a:visited,
+a.visited {
+  border-color: #4c2c92;
+  color: #4c2c92;
+}
+a:hover,
+a.hover {
+  border-style: solid;
+  border-color: #205493;
+  color: #205493;
+}
+a:focus,
+a.focus {
+  border-style: solid;
+  outline: thin dotted;
+}
+a:active,
+a.active {
+  border-style: solid;
+  border-color: #046b99;
+  color: #046b99;
+}
+/* topdoc
+  name: Underlined links
+  family: cf-core
+  patterns:
+    - name: States
+      notes:
+        - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not
+          be used in production."
+        - "The underline style properties are mostly set above in the a tag.
+          To enable the underline simply set a bottom-border-width as done here."
+      markup: |
+        <p>
+            <a href="#">Default</a>,
+            <a href="#" class="visited">Visited</a>,
+            <a href="#" class="hover">Hovered</a>,
+            <a href="#" class="focus">Focused</a>,
+            <a href="#" class="active">Active</a>
+        </p>
+    - name: Underline conditions
+      notes:
+        - "We're restricting link borders to links within p, li, and dd so that
+          we don't have to override them every time we want a plain link."
+      markup: |
+        <p>
+            <a href="#">A child of a paragraph</a>
+        </p>
+        <ul>
+            <li>
+                <a href="#">A child of a list item</a>
+            </li>
+        </ul>
+        <dl>
+            <dt>
+                Definition list term
+            </dt>
+            <dd>
+                <a href="#">A child of a definition list description</a>
+            </dd>
+        </dl>
+    - name: Exceptions for underlined links
+      notes:
+        - "Inline text links inside of a nav element are not underlined."
+      markup: |
+        <nav>
+            <p>
+                <a href="#">A child of a paragraph</a>
+            </p>
+            <ul>
+                <li>
+                    <a href="#">A child of a list item</a>
+                </li>
+            </ul>
+            <dl>
+                <dt>
+                    Definition list term
+                </dt>
+                <dd>
+                    <a href="#">A child of a definition list description</a>
+                </dd>
+            </dl>
+        </nav>
+  tags:
+    - cf-core
+*/
+p a,
+li a,
+dd a {
+  border-bottom-width: 1px;
+}
+nav a {
+  border-bottom-width: 0;
+}
+/* topdoc
+  name: Lists
+  family: cf-core
+  patterns:
+    - name: Unordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
+    - name: Ordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ol>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ol>
+  tags:
+    - cf-core
+*/
+ul {
+  padding-left: 2em;
+  list-style: square;
+}
+ol {
+  padding-left: 1.9375em;
+}
+ol > li {
+  padding-left: 0.0625em;
+}
+/* topdoc
+  name: Tables
+  family: cf-core
+  patterns:
+    - name: Standard table
+      markup: |
+        <table>
+            <thead>
+                <tr>
+                    <th>Column 1 header</th>
+                    <th>Column 2 header</th>
+                    <th>Column 3 header</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Row 1, column 1</td>
+                    <td>Row 1, column 2</td>
+                    <td>Row 1, column 3</td>
+                </tr>
+                <tr>
+                    <td>Row 2, column 1</td>
+                    <td>Row 2, column 2</td>
+                    <td>Row 2, column 3</td>
+                </tr>
+                <tr>
+                    <td>Row 3, column 1</td>
+                    <td>Row 3, column 2</td>
+                    <td>Row 3, column 3</td>
+                </tr>
+            </tbody>
+        </table>
+  tags:
+    - cf-core
+*/
+table {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+th,
+td {
+  padding: 0.625em;
+}
+thead th,
+thead td {
+  color: #212121;
+  background: #f1f1f1;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+thead,
+tbody tr {
+  border-bottom: 1px solid #5b616b;
+}
+th {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  text-align: left;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
+}
+tbody th {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+/* topdoc
+  name: Block quote
+  family: cf-core
+  patterns:
+    - name: Default block quote
+      markup: |
+        <blockquote cite="link-to-source">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Culpa
+            similique fugit hic eligendi praesentium officiis illum optio iusto
+            commodi eum tempore nisi ad in perferendis enim quo dolores.
+            Reprehenderit similique earum quibusdam possimus vitae esse
+            nesciunt mollitia sed beatae aliquid dolores iure a impedit quam
+            minus eum modi illum ducimus eligendi eveniet labore non sequi
+            voluptate et totam praesentium animi itaque asperiores dolorum
+            sunt laudantium repellat nam commodi. Perspiciatis natus aliquam
+            veniam officiis ducimus voluptatum ut necessitatibus non!
+        </blockquote>
+      notes:
+        - "Use a block quote to quote from an external work. See .pull-quote if
+          you need to highlight an excerpt from the current work."
+        - "It is best practice to document the URL of a quoted work using the
+          cite attribute."
+  tags:
+    - cf-core
+*/
+blockquote {
+  margin-right: 0.9375em;
+  margin-left: 0.9375em;
+}
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
+  }
+}
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
+  }
+}
+/* topdoc
+    name: Form labels
+    family: cf-core
+    notes:
+      - "Visit https://github.com/cfpb/cf-forms for advanced form label patterns."
+    patterns:
+    - name: Default label
+      markup: |
+        <label>Form label</label>
+    - name: Label wrapping a radio or checkbox
+      markup: |
+        <label>
+            <input type="radio">
+            Radio label
+        </label>
+        <label>
+            <input type="checkbox">
+            Checkbox label
+        </label>
+    tags:
+    - cf-core
+*/
+label {
+  display: block;
+  margin-bottom: 0.3125em;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label input[type="radio"],
+label input[type="checkbox"] {
+  margin-right: 0.375em;
+}
+/* topdoc
+    name: Form elements
+    family: cf-core
+    notes:
+      - "The .focus class is only included for documentation demos and should
+         not be used in production."
+      - "Visit https://github.com/cfpb/cf-forms for advanced form field patterns."
+    patterns:
+    - name: type="text"
+      markup: |
+        <input type="text" value="Lorem ipsum">
+        <input class="focus" type="text" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="text" value="">
+    - name: type="search"
+      markup: |
+        <input type="search" value="Lorem ipsum">
+        <input class="focus" type="search" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="search" value="">
+    - name: type="email"
+      markup: |
+        <input type="email" value="Lorem ipsum">
+        <input class="focus" type="email" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="email" value="">
+    - name: type="url"
+      markup: |
+        <input type="url" value="Lorem ipsum">
+        <input class="focus" type="url" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="url" value="">
+    - name: type="tel"
+      markup: |
+        <input type="tel" value="Lorem ipsum">
+        <input class="focus" type="tel" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="tel" value="">
+    - name: type="number"
+      markup: |
+        <input type="number" value="1000">
+        <input class="focus" type="number" value="1000">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="number" value="">
+    - name: textarea
+      markup: |
+        <textarea>Lorem ipsum</textarea>
+        <textarea class="focus">Lorem ipsum</textarea>
+    - name: multi-select
+      markup: |
+        <select multiple>
+            <option value="option1">Lorem</option>
+            <option value="option2">Ipsum</option>
+            <option value="option3">Dolor</option>
+            <option value="option4">Sit</option>
+        </select>
+        <select class="focus" multiple>
+            <option value="option1">Lorem</option>
+            <option value="option2">Ipsum</option>
+            <option value="option3">Dolor</option>
+            <option value="option4">Sit</option>
+        </select>
+    tags:
+    - cf-core
+*/
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="url"],
+input[type="tel"],
+input[type="number"],
+textarea,
+select[multiple] {
+  display: inline-block;
+  margin: 0;
+  padding: 0.375em;
+  font-family: Arial, sans-serif;
+  font-size: 1em;
+  background: #ffffff;
+  border: 1px solid #5b616b;
+  border-radius: 0;
+  vertical-align: top;
+  -webkit-appearance: none;
+  -webkit-user-modify: read-write-plaintext-only;
+}
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+input[type="text"]:focus,
+input[type="text"].focus,
+input[type="search"]:focus,
+input[type="search"].focus,
+input[type="email"]:focus,
+input[type="email"].focus,
+input[type="url"]:focus,
+input[type="url"].focus,
+input[type="tel"]:focus,
+input[type="tel"].focus,
+input[type="number"]:focus,
+input[type="number"].focus,
+textarea:focus,
+textarea.focus,
+select[multiple]:focus,
+select[multiple].focus {
+  border: 1px solid #3e94cf;
+  outline: 1px solid #3e94cf;
+  outline-offset: 0;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+::-webkit-input-placeholder {
+  color: grayscale(#c7336e);
+}
+::-moz-placeholder {
+  color: grayscale(#c7336e);
+}
+:-ms-input-placeholder {
+  color: grayscale(#c7336e);
+}
+/* topdoc
+  name: Images
+  family: cf-core
+  patterns:
+    - name: max-width
+      markup: |
+            <img src="http://placekitten.com/800/40" alt="">
+      notes:
+        - "Gives all images a default max-width of 100% of their container."
+  tags:
+    - cf-core
+*/
+img {
+  max-width: 100%;
+}
+/* topdoc
+  name: Figure
+  family: cf-core
+  patterns:
+    - name: figure
+      markup: |
+        <figure>
+            <img src="http://placekitten.com/340/320">
+        </figure>
+    - name: figure.figure__bordered
+      markup: |
+        <figure class="figure__bordered">
+            <img src="http://placekitten.com/340/320">
+        </figure>
+  tags:
+    - cf-core
+*/
+figure {
+  margin-left: 0;
+  margin-right: 0;
+}
+figure img {
+  vertical-align: middle;
+}
+.figure__bordered img {
+  border: 1px solid #d6d7d9;
 }
 /* topdoc
   name: EOF
@@ -2553,8 +7781,8 @@ figure img {
 */
 @font-face {
   font-family: 'CFPB Minicons';
-  src: url('fonts/cf-icons.eot');
-  src: url('fonts/cf-icons.eot?#iefix') format('embedded-opentype'), url('fonts/cf-icons.woff') format('woff'), url('fonts/cf-icons.ttf') format('truetype'), url('fonts/cf-icons.svg') format('svg');
+  src: url('../fonts/cf-icons.eot');
+  src: url('../fonts/cf-icons.eot?#iefix') format('embedded-opentype'), url('../fonts/cf-icons.woff') format('woff'), url('../fonts/cf-icons.ttf') format('truetype'), url('../fonts/cf-icons.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -4443,6 +9671,9 @@ figure img {
 .lt-ie9 .btn {
   font-weight: normal !important;
 }
+.lt-ie9 .btn {
+  font-weight: normal !important;
+}
 .btn,
 .btn:link,
 .btn:visited {
@@ -5032,34 +10263,34 @@ input.btn::-moz-focus-inner {
 */
 .btn__link {
   padding: 0;
-  border-bottom: 1px dotted #c7336e;
+  border-bottom: 1px dotted #0071bc;
   border-radius: 0;
   margin: 0.5em 0;
 }
 .btn__link,
 .btn__link:link,
 .btn__link:visited {
-  border-bottom-color: #cf447c;
+  border-bottom-color: #4c2c92;
   background-color: transparent;
-  color: #cf447c;
+  color: #4c2c92;
 }
 .btn__link:hover,
 .btn__link.hover {
-  border-bottom: 1px solid #9e2958;
+  border-bottom: 1px solid #205493;
   background-color: transparent;
-  color: #9e2958;
+  color: #205493;
 }
 .btn__link:focus,
 .btn__link.focus {
   border-bottom-style: solid;
   background-color: transparent;
-  outline: thin dotted #c7336e;
+  outline: thin dotted #0071bc;
 }
 .btn__link:active,
 .btn__link.active {
-  border-bottom: 1px solid #8a234c;
+  border-bottom: 1px solid #046b99;
   background-color: transparent;
-  color: #8a234c;
+  color: #046b99;
 }
 .lt-ie8 button.btn__link,
 .lt-ie8 input.btn__link {
@@ -5213,13 +10444,21 @@ input.btn::-moz-focus-inner {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  margin-top: 0;
-  margin-bottom: 0.35714286em;
+  margin-bottom: 1.07142857em;
   font-size: 0.875em;
-  line-height: 1.57142857;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
   margin-bottom: 0.71428571em;
+}
+.lt-ie9 .form-label-header {
+  font-weight: normal !important;
+}
+.lt-ie9 .form-label-header {
+  font-weight: normal !important;
+}
+.lt-ie9 .form-label-header {
+  font-weight: normal !important;
 }
 .lt-ie9 .form-label-header {
   font-weight: normal !important;
@@ -5253,6 +10492,9 @@ input.btn::-moz-focus-inner {
     - name: Error state
       codenotes:
         - .error
+      notes:
+        - "See the 'Form icons' section below for guidance on adding icons to
+           states."
       markup: |
         <input class="error" type="text" value="Invalid input" title="Test input">
     - name: Warning state
@@ -5502,6 +10744,14 @@ textarea.disabled {
     margin-right: -15px;
   }
 }
+@media only all and (min-width: 30em) {
+  .input-with-btn {
+    display: block;
+    position: relative;
+    margin-left: -15px;
+    margin-right: -15px;
+  }
+}
 .input-with-btn_input {
   margin-bottom: 0.9375em;
 }
@@ -5516,6 +10766,46 @@ textarea.disabled {
     margin-right: -0.25em;
     vertical-align: top;
     width: 75%;
+    border-right-width: 0;
+  }
+  .lt-ie8 .input-with-btn_input {
+    display: inline;
+    margin-right: 0;
+    zoom: 1;
+    behavior: url('../../box-sizing-polyfill/boxsizing.htc');
+  }
+}
+@media only all and (min-width: 30em) {
+  .input-with-btn_input {
+    display: inline-block;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    border: solid transparent;
+    border-width: 0 15px;
+    margin-right: -0.25em;
+    vertical-align: top;
+    width: 75%;
+    border-right-width: 0;
+  }
+  .lt-ie8 .input-with-btn_input {
+    display: inline;
+    margin-right: 0;
+    zoom: 1;
+    behavior: url('../../box-sizing-polyfill/boxsizing.htc');
+  }
+}
+@media only all and (min-width: 60em) {
+  .input-with-btn_input {
+    display: inline-block;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    border: solid transparent;
+    border-width: 0 15px;
+    margin-right: -0.25em;
+    vertical-align: top;
+    width: 83.33333333%;
     border-right-width: 0;
   }
   .lt-ie8 .input-with-btn_input {
@@ -5565,6 +10855,44 @@ textarea.disabled {
     margin-right: -0.25em;
     vertical-align: top;
     width: 25%;
+  }
+  .lt-ie8 .input-with-btn_btn {
+    display: inline;
+    margin-right: 0;
+    zoom: 1;
+    behavior: url('../../box-sizing-polyfill/boxsizing.htc');
+  }
+}
+@media only all and (min-width: 30em) {
+  .input-with-btn_btn {
+    display: inline-block;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    border: solid transparent;
+    border-width: 0 15px;
+    margin-right: -0.25em;
+    vertical-align: top;
+    width: 25%;
+  }
+  .lt-ie8 .input-with-btn_btn {
+    display: inline;
+    margin-right: 0;
+    zoom: 1;
+    behavior: url('../../box-sizing-polyfill/boxsizing.htc');
+  }
+}
+@media only all and (min-width: 60em) {
+  .input-with-btn_btn {
+    display: inline-block;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    border: solid transparent;
+    border-width: 0 15px;
+    margin-right: -0.25em;
+    vertical-align: top;
+    width: 16.66666667%;
   }
   .lt-ie8 .input-with-btn_btn {
     display: inline;
@@ -5670,4 +10998,4 @@ textarea.disabled {
   name: EOF
   eof: true
 */
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1jc3Mvbm9ybWFsaXplLmNzcyIsIi8uLi9ub3JtYWxpemUtbGVnYWN5LWFkZG9uL25vcm1hbGl6ZS1sZWdhY3ktYWRkb24uY3NzIiwiLy4uL2NmLWNvcmUvc3JjL2NmLXV0aWxpdGllcy5sZXNzIiwiLy4uL2NmLWNvcmUvc3JjL2NmLW1lZGlhLXF1ZXJpZXMubGVzcyIsIi8uLi9jZi1jb3JlL3NyYy9jZi1iYXNlLmxlc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtdmFycy5sZXNzIiwiLy4uL2NmLWljb25zL3NyYy9jZi1pY29ucy5sZXNzIiwiLy4uL2NmLWJ1dHRvbnMvc3JjL2NmLWJ1dHRvbnMubGVzcyIsIi9zcmMvY2YtZm9ybXMubGVzcyIsIi8uLi9jZi1ncmlkL3NyYy9jZi1ncmlkLmxlc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7O0FBUUE7RUFDRSx1QkFBQTs7RUFDQSwwQkFBQTs7RUFDQSw4QkFBQTs7Ozs7O0FBT0Y7RUFDRSxTQUFBOzs7Ozs7Ozs7O0FBYUY7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRSxjQUFBOzs7Ozs7QUFRRjtBQUNBO0FBQ0E7QUFDQTtFQUNFLHFCQUFBOztFQUNBLHdCQUFBOzs7Ozs7O0FBUUYsS0FBSyxJQUFJO0VBQ1AsYUFBQTtFQUNBLFNBQUE7Ozs7OztBQVFGO0FBQ0E7RUFDRSxhQUFBOzs7Ozs7O0FBVUY7RUFDRSw2QkFBQTs7Ozs7O0FBUUYsQ0FBQztBQUNELENBQUM7RUFDQyxVQUFBOzs7Ozs7O0FBVUYsSUFBSTtFQUNGLHlCQUFBOzs7OztBQU9GO0FBQ0E7RUFDRSxpQkFBQTs7Ozs7QUFPRjtFQUNFLGtCQUFBOzs7Ozs7QUFRRjtFQUNFLGNBQUE7RUFDQSxnQkFBQTs7Ozs7QUFPRjtFQUNFLGdCQUFBO0VBQ0EsV0FBQTs7Ozs7QUFPRjtFQUNFLGNBQUE7Ozs7O0FBT0Y7QUFDQTtFQUNFLGNBQUE7RUFDQSxjQUFBO0VBQ0Esa0JBQUE7RUFDQSx3QkFBQTs7QUFHRjtFQUNFLFdBQUE7O0FBR0Y7RUFDRSxlQUFBOzs7Ozs7O0FBVUY7RUFDRSxTQUFBOzs7OztBQU9GLEdBQUcsSUFBSTtFQUNMLGdCQUFBOzs7Ozs7O0FBVUY7RUFDRSxnQkFBQTs7Ozs7QUFPRjtFQUNFLHVCQUFBO0VBQ0EsU0FBQTs7Ozs7QUFPRjtFQUNFLGNBQUE7Ozs7O0FBT0Y7QUFDQTtBQUNBO0FBQ0E7RUFDRSxpQ0FBQTtFQUNBLGNBQUE7Ozs7Ozs7Ozs7Ozs7O0FBa0JGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRSxjQUFBOztFQUNBLGFBQUE7O0VBQ0EsU0FBQTs7Ozs7O0FBT0Y7RUFDRSxpQkFBQTs7Ozs7Ozs7QUFVRjtBQUNBO0VBQ0Usb0JBQUE7Ozs7Ozs7OztBQVdGO0FBQ0EsSUFBSyxNQUFLO0FBQ1YsS0FBSztBQUNMLEtBQUs7RUFDSCwwQkFBQTs7RUFDQSxlQUFBOzs7Ozs7QUFPRixNQUFNO0FBQ04sSUFBSyxNQUFLO0VBQ1IsZUFBQTs7Ozs7QUFPRixNQUFNO0FBQ04sS0FBSztFQUNILFNBQUE7RUFDQSxVQUFBOzs7Ozs7QUFRRjtFQUNFLG1CQUFBOzs7Ozs7Ozs7QUFXRixLQUFLO0FBQ0wsS0FBSztFQUNILHNCQUFBOztFQUNBLFVBQUE7Ozs7Ozs7O0FBU0YsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtFQUNsQixZQUFBOzs7Ozs7QUFRRixLQUFLO0VBQ0gsNkJBQUE7O0VBQ0EsdUJBQUE7Ozs7Ozs7O0FBU0YsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtFQUNsQix3QkFBQTs7Ozs7QUFPRjtFQUNFLHlCQUFBO0VBQ0EsYUFBQTtFQUNBLDhCQUFBOzs7Ozs7QUFRRjtFQUNFLFNBQUE7O0VBQ0EsVUFBQTs7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7Ozs7QUFRRjtFQUNFLGlCQUFBOzs7Ozs7O0FBVUY7RUFDRSx5QkFBQTtFQUNBLGlCQUFBOztBQUdGO0FBQ0E7RUFDRSxVQUFBOzs7Ozs7Ozs7QUM1WkY7QUFDQTtBQUNBO0VBQ0ksZ0JBQUE7RUFDQSxRQUFBOzs7Ozs7Ozs7QUFZSjtFQUNJLGVBQUE7Ozs7OztBQVFKO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDSSx1QkFBQTs7Ozs7Ozs7OztBQWFKO0VBQ0ksZ0JBQUE7O0FBR0o7RUFDSSxnQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0ksaUJBQUE7RUFDQSxhQUFBOztBQUdKO0VBQ0ksY0FBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0ksaUJBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDSSxnQkFBQTs7Ozs7QUFPSjtBQUNBO0VBQ0ksYUFBQTs7Ozs7QUFPSjtBQUNBO0FBQ0E7QUFDQTtFQUNJLGNBQWMsd0JBQWQ7Ozs7O0FBT0o7RUFDSSxnQkFBQTtFQUNBLHFCQUFBOzs7OztBQU9KO0VBQ0ksWUFBQTs7Ozs7QUFPSixDQUFDO0FBQ0QsQ0FBQztFQUNHLFNBQVMsRUFBVDtFQUNBLGFBQUE7Ozs7Ozs7O0FBV0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSxhQUFBOztBQUdKO0VBQ0ksa0JBQUE7Ozs7O0FBT0o7QUFDQTtBQUNBO0VBQ0ksbUJBQUE7Ozs7O0FBT0osR0FBSTtBQUNKLEdBQUk7RUFDQSxnQkFBQTtFQUNBLHNCQUFBOzs7Ozs7OztBQVdKO0VBQ0ksK0JBQUE7Ozs7Ozs7O0FBV0o7RUFDSSxTQUFBOzs7Ozs7O0FBU0o7RUFDSSxTQUFBOztFQUNBLG1CQUFBOztFQUNBLGtCQUFBOzs7Ozs7QUFPSjtBQUNBO0FBQ0E7QUFDQTtFQUNJLHdCQUFBO0VBQ0EsdUJBQUE7Ozs7OztBQVFKO0FBQ0EsSUFBSyxNQUFLO0FBQ1YsS0FBSztBQUNMLEtBQUs7RUFDRCxrQkFBQTs7Ozs7O0FBUUosS0FBSztBQUNMLEtBQUs7RUFDRCxhQUFBO0VBQ0EsWUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQzlNQSxNQUFPO0VBQ0gsd0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBeUJKLFdBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTs7QUFFSixPQUFRO0VBQ0osT0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTBCUjtFQUNFLGtCQUFBO0VBQ0EsZ0JBQUE7RUFDQSxNQUFNLGFBQU47RUFDQSxXQUFBO0VBQWEsVUFBQTtFQUNiLFlBQUE7RUFBYyxVQUFBO0VBQVksU0FBQTs7Ozs7Ozs7Ozs7Ozs7QUFpQjVCO0VBQ0kscUJBQUE7O0FBQ0EsT0FBUTtFQUVKLGVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBd0JSO0VBQ0ksWUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb0NKO0VBQ0kscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW1ISjtFQUxJLGtCQUFBO0VBQ0Esc0JBQUE7RUFDQSxTQUFBOztBQU9KO0VBQ0ksa0JBQUE7RUFDQSxNQUFBO0VBQ0EsT0FBQTtFQUNBLFdBQUE7RUFDQSxZQUFBOztBQUdKO0VBakJJLGtCQUFBO0VBQ0EsbUJBQUE7RUFDQSxTQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9OSjtFQUFVLHdCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSwwQkFBQTs7QUFDVjtFQUFVLDZCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTBEVjtFQUFhLFdBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLG1CQUFBOztBQUNiO0VBQWEsbUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FDOWZiLHFCQUgwQztFQUcxQztJRHFpQlEsYUFBQTs7O0FBSVI7RUFDSSxhQUFBOztBQzFpQkoscUJBSDBDO0VBRzFDO0lENGlCUSxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW1EUjtFQUhFLGtCQUFBOztBQU9GO0VBUEUsa0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUVyaUJGO0VBQ0ksY0FBQTtFQUNBLHNCQUFzQix3QkFBdEI7RUFDQSxlQUFBO0VBQ0Esa0JBQUE7O0FBR0o7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBeEdJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFFQSxFQUFFO0FBQUYsR0FBRTtBQUFGLEVBQUU7QUFBRixHQUFFO0FBQUYsRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtBQUFGLEVBQUU7QUFBRixHQUFFO0FBQUYsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0FBY0YsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0FBY0YsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFBRixFQUFFO0FBQUYsR0FBRTtBQUFGLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7QUFBRixFQUFFO0FBQUYsR0FBRTtBQUFGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUFDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47QUEyQkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0FBMkJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUFzRVI7QUFDQTtFQUlJLGFBQUE7RUFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FEakZKLHFCQUgwQztFQUcxQztFQUFBO0lDckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQWdJQSxhQUFBO0lBR0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLHVCQUFBOztFQW5JQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFQUNBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFQUNBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7OztBRERSLHFCQUgwQyx3Q0FBQTtFQUcxQztFQUFBO0lDckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQWlKQSxhQUFBO0lBR0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLHVCQUFBOztFQXBKQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFQUNBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFQUNBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7OztBRERSLHFCQUgwQyx3Q0FBQSx3Q0FBQTtFQUcxQztFQUFBO0lDOEhJLGFBQUE7SUFHQSwyQkFBQTtJQUNBLGtCQUFBO0lBOUlBLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxnQkFBQTtJQThJQSx1QkFBQTs7RUE3SUEsT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7O0FBZ0dSO0FBQ0E7RUFJSSxhQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLHVCQUFBOztBRGxHSixxQkFIMEM7RUFHMUM7RUFBQTtJQ3JDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUFpSkEsYUFBQTtJQUdBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSx1QkFBQTs7RUFwSkEsRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RUFDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUFDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOzs7QUREUixxQkFIMEMsd0NBQUE7RUFHMUM7RUFBQTtJQzhISSxhQUFBO0lBR0EsMkJBQUE7SUFDQSxrQkFBQTtJQTlJQSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsZ0JBQUE7SUE4SUEsdUJBQUE7O0VBN0lBLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7OztBQWlIUjtBQUNBO0VBSUksYUFBQTtFQUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSx1QkFBQTs7QURuSEoscUJBSDBDO0VBRzFDO0VBQUE7SUM4SEksYUFBQTtJQUdBLDJCQUFBO0lBQ0Esa0JBQUE7SUE5SUEscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGdCQUFBO0lBOElBLHVCQUFBOztFQTdJQSxPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOzs7QUFrSVI7QUFDQTtFQUdJLGFBQUE7RUFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBOUlBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTtFQThJQSx1QkFBQTs7QUE3SUEsT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUErSVI7QUFDQTtBQUNBO0FBQ0E7RUE3SUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBOElBLG1CQUFBO0VBQ0EseUJBQUE7O0FBOUlBLE9BQVE7QUFBUixPQUFRO0FBQVIsT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUFnSlI7QUFDQTtFQUdJLGFBQUE7RUFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBR0o7QUFDQTtFQUdJLGFBQUE7RUFHQSwyQkFBQTtFQUNBLGlCQUFBO0VBQ0EsdUJBQUE7O0FBR0o7RUFLSSxhQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQXZOQSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUF1TkEsdUJBQUE7O0FBck5BLFVBQUU7QUFDRixVQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBQUNBLE9BQVEsV0FmTjtBQWVGLE9BQVEsV0FkTjtFQWVFLDZCQUFBOztBQVhKLFVBQUU7QUFDRixVQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUFDQSxPQUFRLFdBNUJOO0FBNEJGLE9BQVEsV0EzQk47RUE0QkUsOEJBQUE7O0FBc0xSO0VBUUksdUJBQUE7RUFDQSxjQUFBO0VBbk1BLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQW1NQSxpQkFBQTs7QUFsTUEsT0FBUTtFQUNKLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7QUFtTlI7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTtFQUVBLHFCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE4Qko7RUFDSSxlQUFBO0VBQ0Esb0JBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7RUFDQSxxQkFBQTs7QUFFQSxDQUFDO0FBQ0QsQ0FBQztFQUNHLHFCQUFBO0VBQ0EsY0FBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxvQkFBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzRVIsQ0FLSTtBQUpKLEVBSUk7QUFISixFQUdJO0VBQ0ksd0JBQUE7O0FBSVIsR0FBSTtFQUVBLHNCQUFBOzs7Ozs7Ozs7Ozs7Ozs7O0FBbUJKO0VBQ0ksa0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzRUo7RUF6ZUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBQUVBLEtBQUU7QUFDRixLQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBQUNBLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQVhKLEtBQUU7QUFDRixLQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUFDQSxPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FBdWNSO0FBQ0E7RUFDSSx3QkFBQTtFQUNBLG1CQUFBOztBQUVBLEtBQU07QUFBTixLQUFNO0VBQ0YsY0FBQTtFQUNBLG1CQUFBOztBQUdKLEtBQU0sS0FBSSxVQUFVLEtBQU07QUFBMUIsS0FBTSxLQUFJLFVBQVUsS0FBTTtFQUN0QixtQkFBQTs7QUFHSixjQUFlO0FBQWYsY0FBZTtFQUNYLHlCQUFBOztBQUlSO0VBOWRJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQThkQSxnQkFBQTs7QUE3ZEEsT0FBUTtFQUNKLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEwZlI7RUFFSSxjQUFBOztBQU1KLHFCQUo0RTtFQUk1RTtJQUhRLG9CQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF5QlI7RUE5akJJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQWlKQSxhQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLHVCQUFBOztBQXBKQSxNQUFFO0FBQ0YsTUFBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFDQSxPQUFRLE9BZk47QUFlRixPQUFRLE9BZE47RUFlRSw2QkFBQTs7QUFYSixNQUFFO0FBQ0YsTUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxPQTVCTjtBQTRCRixPQUFRLE9BM0JOO0VBNEJFLDhCQUFBOztBRERSLHFCQUgwQztFQUcxQztJQzhISSxhQUFBO0lBR0EsMkJBQUE7SUFDQSxrQkFBQTtJQTlJQSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsZ0JBQUE7SUE4SUEsdUJBQUE7O0VBN0lBLE9BQVE7SUFDSiw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTZqQlI7RUFDSSxjQUFBO0VBRUEsdUJBQUE7RUE3bEJBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFFQSxLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFDQSxPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBQW9qQlIsS0FNSSxNQUFLO0FBTlQsS0FPSSxNQUFLO0VBQ0QscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1RVIsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0w7QUFDQSxNQUFNO0VBR0YscUJBQUE7RUFDQSxTQUFBO0VBQ0EsZ0JBQUE7RUFDQSw4QkFBQTtFQUNBLGNBQUE7RUFDQSxtQkFBQTtFQUNBLHlCQUFBO0VBQ0EsZ0JBQUE7RUFDQSxtQkFBQTtFQUNBLHdCQUFBO0VBQ0EsOENBQUE7O0FBS0o7RUFDSSx3QkFBQTs7QUFLSixLQUFLLGFBQWE7QUFDbEIsS0FBSyxhQUFhO0FBQ2xCLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxjQUFjO0FBQ25CLEtBQUssY0FBYztBQUNuQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtBQUNwQixRQUFRO0FBQ1IsUUFBUTtBQUNSLE1BQU0sVUFBVTtBQUNoQixNQUFNLFVBQVU7RUFDWix5QkFBQTtFQUNBLDBCQUFBO0VBQ0EsaUJBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNHLE9DM3JCNkIsa0JEMnJCN0I7O0FBRUg7RUFDRyxPQzlyQjZCLGtCRDhyQjdCOztBQUVIO0VBQ0csT0Nqc0I2QixrQkRpc0I3Qjs7Ozs7Ozs7Ozs7Ozs7QUFpQkg7RUFDSSxlQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBc0JKO0VBQ0ksY0FBQTtFQUNBLGVBQUE7O0FBRkosTUFJSTtFQUVJLHNCQUFBOztBQUlSLGlCQUFrQjtFQUNkLHlCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUUxdkJKO0VBQ0UsYUFBYSxlQUFiO0VBQ0EsU0FBUyxxQkFBVDtFQUNBLFNBQVMsNkJBQXVDLE9BQU8sMEJBQ2pELHVCQUFpQyxPQUFPLGFBQ3hDLHNCQUFnQyxPQUFPLGlCQUN2QyxzQkFBZ0MsT0FBTyxNQUg3QztFQUlBLG1CQUFBO0VBQ0Esa0JBQUE7O0FBZ0JGO0FBQ0EsQ0FBQztFQUNDLGFBQWEsZUFBYjtFQUNBLHFCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGNBQUE7RUFDQSxtQ0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvUUYsQ0FBQyxPQUFpQjtFQUNoQix1QkFBQTtFQUNBLG1CQUFBO0VBQ0Esb0JBQUE7O0FBR0YsQ0FBQyxPQUFpQjtFQUFPLGNBQUE7O0FBQ3pCLENBQUMsT0FBaUI7RUFBTyxjQUFBOztBQUN6QixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7QUFDekIsQ0FBQyxPQUFpQjtFQUFPLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBNkR6QixDQUFDLE9BQWlCO0VBQ2hCLHlCQUFBO0VBQ0EsNEJBQUE7RUFDQSxtQkFBQTs7QUFHRixDQUFDLE9BQWlCO0VBekNoQixRQUFRLHdEQUFSO0VBQ0EsbUJBQW1CLGFBQW5CO0VBQ0ksZUFBZSxhQUFmO0VBQ0ksV0FBVyxhQUFYOztBQXVDVixDQUFDLE9BQWlCO0VBMUNoQixRQUFRLHdEQUFSO0VBQ0EsbUJBQW1CLGNBQW5CO0VBQ0ksZUFBZSxjQUFmO0VBQ0ksV0FBVyxjQUFYOztBQXdDVixDQUFDLE9BQWlCO0VBM0NoQixRQUFRLHdEQUFSO0VBQ0EsbUJBQW1CLGNBQW5CO0VBQ0ksZUFBZSxjQUFmO0VBQ0ksV0FBVyxjQUFYOztBQTBDVixDQUFDLE9BQWlCO0VBdENoQixRQUFRLGtFQUFSO0VBQ0EsbUJBQW1CLFlBQW5CO0VBQ0ksZUFBZSxZQUFmO0VBQ0ksV0FBVyxZQUFYOztBQW9DVixDQUFDLE9BQWlCO0VBdkNoQixRQUFRLGtFQUFSO0VBQ0EsbUJBQW1CLFlBQW5CO0VBQ0ksZUFBZSxZQUFmO0VBQ0ksV0FBVyxZQUFYOztBQXNDVixLQUFNLEVBQUMsT0FBaUI7QUFDeEIsS0FBTSxFQUFDLE9BQWlCO0FBQ3hCLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7QUFDeEIsS0FBTSxFQUFDLE9BQWlCO0VBQ3RCLFlBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzQkYsQ0FBQyxPQUFpQjtFQUNoQiw2Q0FBQTtFQUNRLHFDQUFBOztBQUdWLENBQUMsT0FBaUI7RUFDaEIsdUNBQXVDLFFBQXZDO0VBQ1EsK0JBQStCLFFBQS9COztBQUdWO0VBQ0U7SUFDRSxtQkFBbUIsWUFBbkI7SUFDUSxXQUFXLFlBQVg7O0VBRVY7SUFDRSxtQkFBbUIsY0FBbkI7SUFDUSxXQUFXLGNBQVg7OztBQUlaO0VBQ0U7SUFDRSxtQkFBbUIsWUFBbkI7SUFDUSxXQUFXLFlBQVg7O0VBRVY7SUFDRSxtQkFBbUIsY0FBbkI7SUFDUSxXQUFXLGNBQVg7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQThDUixDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxmZCw2RUFBQTs7QUF3ZkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2ZmQsNkVBQUE7O0FBNmZBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNWZkLDZFQUFBOztBQWtnQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqZ0JkLDZFQUFBOztBQXVnQkEsQ0FESCxPQUFpQixHQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0Z0JkLDZFQUFBOztBQTRnQkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzZ0JkLDZFQUFBOztBQWloQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoaEJkLDZFQUFBOztBQXNoQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyaEJkLDZFQUFBOztBQTJoQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExaEJkLDZFQUFBOztBQWdpQkEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL2hCZCw2RUFBQTs7QUFxaUJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcGlCZCw2RUFBQTs7QUEwaUJBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXppQmQsNkVBQUE7O0FBK2lCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTlpQmQsNkVBQUE7O0FBb2pCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5qQmQsNkVBQUE7O0FBeWpCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhqQmQsNkVBQUE7O0FBOGpCQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3akJkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBd21CQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZtQmQsNkVBQUE7O0FBNm1CQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVtQmQsNkVBQUE7O0FBa25CQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpuQmQsNkVBQUE7O0FBdW5CQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRuQmQsNkVBQUE7O0FBNG5CQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNuQmQsNkVBQUE7O0FBaW9CQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhvQmQsNkVBQUE7O0FBc29CQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJvQmQsNkVBQUE7O0FBMm9CQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFvQmQsNkVBQUE7O0FBZ3BCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9vQmQsNkVBQUE7O0FBcXBCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBwQmQsNkVBQUE7O0FBMHBCQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXpwQmQsNkVBQUE7O0FBK3BCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTlwQmQsNkVBQUE7O0FBb3FCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5xQmQsNkVBQUE7O0FBeXFCQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhxQmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFtdEJBLENBREgsT0FBaUIsUUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHRCZCw2RUFBQTs7QUF3dEJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdnRCZCw2RUFBQTs7QUE2dEJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXRCZCw2RUFBQTs7QUFrdUJBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWp1QmQsNkVBQUE7O0FBdXVCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXR1QmQsNkVBQUE7O0FBNHVCQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzdUJkLDZFQUFBOztBQWl2QkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFodkJkLDZFQUFBOztBQXN2QkEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFydkJkLDZFQUFBOztBQTJ2QkEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExdkJkLDZFQUFBOztBQWd3QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvdkJkLDZFQUFBOztBQXF3QkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwd0JkLDZFQUFBOztBQTB3QkEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6d0JkLDZFQUFBOztBQSt3QkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5d0JkLDZFQUFBOztBQW94QkEsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnhCZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMHpCQSxDQURILE9BQWlCLElBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp6QmQsNkVBQUE7O0FBK3pCQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl6QmQsNkVBQUE7O0FBbzBCQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW4wQmQsNkVBQUE7O0FBeTBCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXgwQmQsNkVBQUE7O0FBODBCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTcwQmQsNkVBQUE7O0FBbTFCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWwxQmQsNkVBQUE7O0FBdzFCQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXYxQmQsNkVBQUE7O0FBNjFCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTUxQmQsNkVBQUE7O0FBazJCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWoyQmQsNkVBQUE7O0FBdTJCQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0MkJkLDZFQUFBOztBQTQyQkEsQ0FESCxPQUFpQixJQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzMkJkLDZFQUFBOztBQWkzQkEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoM0JkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErNkJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOTZCZCw2RUFBQTs7QUFvN0JBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbjdCZCw2RUFBQTs7QUF5N0JBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeDdCZCw2RUFBQTs7QUE4N0JBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNzdCZCw2RUFBQTs7QUFtOEJBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbDhCZCw2RUFBQTs7QUF3OEJBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdjhCZCw2RUFBQTs7QUE2OEJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNThCZCw2RUFBQTs7QUFrOUJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBajlCZCw2RUFBQTs7QUF1OUJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdDlCZCw2RUFBQTs7QUE0OUJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMzlCZCw2RUFBQTs7QUFpK0JBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaCtCZCw2RUFBQTs7QUFzK0JBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcitCZCw2RUFBQTs7QUEyK0JBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMStCZCw2RUFBQTs7QUFnL0JBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBLytCZCw2RUFBQTs7QUFxL0JBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcC9CZCw2RUFBQTs7QUEwL0JBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBei9CZCw2RUFBQTs7QUErL0JBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOS9CZCw2RUFBQTs7QUFvZ0NBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbmdDZCw2RUFBQTs7QUF5Z0NBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeGdDZCw2RUFBQTs7QUE4Z0NBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN2dDZCw2RUFBQTs7QUFtaENBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbGhDZCw2RUFBQTs7QUF3aENBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZoQ2QsNkVBQUE7O0FBNmhDQSxDQURILE9BQWlCLElBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVoQ2QsNkVBQUE7O0FBa2lDQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWppQ2QsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBZ29DQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9uQ2QsNkVBQUE7O0FBcW9DQSxDQURILE9BQWlCLG1CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwb0NkLDZFQUFBOztBQTBvQ0EsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6b0NkLDZFQUFBOztBQStvQ0EsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOW9DZCw2RUFBQTs7QUFvcENBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnBDZCw2RUFBQTs7QUF5cENBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHBDZCw2RUFBQTs7QUE4cENBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3BDZCw2RUFBQTs7QUFtcUNBLENBREgsT0FBaUIscUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxxQ2QsNkVBQUE7O0FBd3FDQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZxQ2QsNkVBQUE7O0FBNnFDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVxQ2QsNkVBQUE7O0FBa3JDQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqckNkLDZFQUFBOztBQXVyQ0EsQ0FESCxPQUFpQixzQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHJDZCw2RUFBQTs7QUE0ckNBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3JDZCw2RUFBQTs7QUFpc0NBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhzQ2QsNkVBQUE7O0FBc3NDQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJzQ2QsNkVBQUE7O0FBMnNDQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFzQ2QsNkVBQUE7O0FBZ3RDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9zQ2QsNkVBQUE7O0FBcXRDQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwdENkLDZFQUFBOztBQTB0Q0EsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6dENkLDZFQUFBOztBQSt0Q0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5dENkLDZFQUFBOztBQW91Q0EsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFudUNkLDZFQUFBOztBQXl1Q0EsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHVDZCw2RUFBQTs7QUE4dUNBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTd1Q2QsNkVBQUE7O0FBbXZDQSxDQURILE9BQWlCLDBCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsdkNkLDZFQUFBOztBQXd2Q0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2dkNkLDZFQUFBOztBQTZ2Q0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXZDZCw2RUFBQTs7QUFrd0NBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBandDZCw2RUFBQTs7QUF1d0NBLENBREgsT0FBaUIscUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXR3Q2QsNkVBQUE7O0FBNHdDQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTN3Q2QsNkVBQUE7O0FBaXhDQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoeENkLDZFQUFBOztBQXN4Q0EsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyeENkLDZFQUFBOztBQTJ4Q0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExeENkLDZFQUFBOztBQWd5Q0EsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3hDZCw2RUFBQTs7QUFxeUNBLENBREgsT0FBaUIsc0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB5Q2QsNkVBQUE7O0FBMHlDQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp5Q2QsNkVBQUE7O0FBK3lDQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5eUNkLDZFQUFBOztBQW96Q0EsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuekNkLDZFQUFBOztBQXl6Q0EsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHpDZCw2RUFBQTs7QUE4ekNBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3pDZCw2RUFBQTs7QUFtMENBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWwwQ2QsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQWkrQ0EsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoK0NkLDZFQUFBOztBQXMrQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyK0NkLDZFQUFBOztBQTIrQ0EsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExK0NkLDZFQUFBOztBQWcvQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvK0NkLDZFQUFBOztBQXEvQ0EsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwL0NkLDZFQUFBOztBQTAvQ0EsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6L0NkLDZFQUFBOztBQSsvQ0EsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5L0NkLDZFQUFBOztBQW9nREEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuZ0RkLDZFQUFBOztBQXlnREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4Z0RkLDZFQUFBOztBQThnREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3Z0RkLDZFQUFBOztBQW1oREEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsaERkLDZFQUFBOztBQXdoREEsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdmhEZCw2RUFBQTs7QUE2aERBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNWhEZCw2RUFBQTs7QUFraURBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWppRGQsNkVBQUE7O0FBdWlEQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRpRGQsNkVBQUE7O0FBNGlEQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzaURkLDZFQUFBOztBQWlqREEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoakRkLDZFQUFBOztBQXNqREEsQ0FESCxPQUFpQixtQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcmpEZCw2RUFBQTs7QUEyakRBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMWpEZCw2RUFBQTs7QUFna0RBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9qRGQsNkVBQUE7O0FBcWtEQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBrRGQsNkVBQUE7O0FBMGtEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXprRGQsNkVBQUE7O0FBK2tEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTlrRGQsNkVBQUE7O0FBb2xEQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFubERkLDZFQUFBOztBQXlsREEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4bERkLDZFQUFBOztBQThsREEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3bERkLDZFQUFBOztBQW1tREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsbURkLDZFQUFBOztBQXdtREEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdm1EZCw2RUFBQTs7QUE2bURBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNW1EZCw2RUFBQTs7QUFrbkRBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBam5EZCw2RUFBQTs7QUF1bkRBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdG5EZCw2RUFBQTs7QUE0bkRBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM25EZCw2RUFBQTs7QUFpb0RBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaG9EZCw2RUFBQTs7QUFzb0RBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcm9EZCw2RUFBQTs7QUEyb0RBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMW9EZCw2RUFBQTs7QUFncERBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL29EZCw2RUFBQTs7QUFxcERBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHBEZCw2RUFBQTs7QUEwcERBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenBEZCw2RUFBQTs7QUErcERBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXBEZCw2RUFBQTs7QUFvcURBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnFEZCw2RUFBQTs7QUF5cURBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHFEZCw2RUFBQTs7QUE4cURBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3FEZCw2RUFBQTs7QUFtckRBLENBREgsT0FBaUIsUUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHJEZCw2RUFBQTs7QUF3ckRBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdnJEZCw2RUFBQTs7QUE2ckRBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVyRGQsNkVBQUE7O0FBa3NEQSxDQURILE9BQWlCLHdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqc0RkLDZFQUFBOztBQXVzREEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0c0RkLDZFQUFBOztBQTRzREEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3NEZCw2RUFBQTs7QUFpdERBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHREZCw2RUFBQTs7QUFzdERBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ0RGQsNkVBQUE7O0FBMnREQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF0RGQsNkVBQUE7O0FBZ3VEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS90RGQsNkVBQUE7O0FBcXVEQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB1RGQsNkVBQUE7O0FBMHVEQSxDQURILE9BQWlCLG1CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6dURkLDZFQUFBOztBQSt1REEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5dURkLDZFQUFBOztBQW92REEsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnZEZCw2RUFBQTs7QUF5dkRBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHZEZCw2RUFBQTs7QUE4dkRBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTd2RGQsNkVBQUE7O0FBbXdEQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWx3RGQsNkVBQUE7O0FBd3dEQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2d0RkLDZFQUFBOztBQTZ3REEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1d0RkLDZFQUFBOztBQWt4REEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqeERkLDZFQUFBOztBQXV4REEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0eERkLDZFQUFBOztBQTR4REEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzeERkLDZFQUFBOztBQWl5REEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoeURkLDZFQUFBOztBQXN5REEsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnlEZCw2RUFBQTs7QUEyeURBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXlEZCw2RUFBQTs7QUFnekRBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS95RGQsNkVBQUE7O0FBcXpEQSxDQURILE9BQWlCLFFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB6RGQsNkVBQUE7O0FBMHpEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp6RGQsNkVBQUE7O0FBK3pEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl6RGQsNkVBQUE7O0FBbzBEQSxDQURILE9BQWlCLHFCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuMERkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUNzRUo7RUFFSSxxQkFBQTtFQUNBLHNCQUFBO0VBQ0Esc0JBQUE7RUFHQSxTQUFBO0VBQ0EscUJBQUE7RUFDQSxTQUFBO0VBRUEsc0JBQUE7RUg5REEscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGdCQUFBO0VHK0RBLGNBQUE7RUFDQSxtQkFBQTtFQUNBLHFCQUFBO0VBRUEsZUFBQTtFQUNBLGlDQUFBO0VBQ0Esd0JBQUE7O0FIcEVBLE9BQVE7RUFDSiw4QkFBQTs7QUdxRUo7QUFDQSxJQUFDO0FBQ0QsSUFBQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTs7QUFHSixJQUFDO0FBQ0QsSUFBQztFQUNHLHlCQUFBOztBQUdKLElBQUM7QUFDRCxJQUFDO0VBQ0cseUJBQUE7RUFDQSwyQkFBQTtFQUdBLG1CQUFBOztBQUdKLElBQUM7QUFDRCxJQUFDO0VBQ0cseUJBQUE7O0FBR0osTUFBTSxJQUFDO0FBQ1AsS0FBSyxJQUFDO0VBR0YsU0FBQTs7QUFHSixJQUFFO0VBQ0Usb0JBQUE7O0FBSVI7RUFLUSxxQ0FBQTs7QUFMUixPQVNJLE9BQU07QUFUVixPQVVJLE1BQUs7RUFDRCxpQkFBQTtFQUNBLGtCQUFBO0VBQ0EscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBdUNKO0FBQ0EsZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTtFQUNBLGNBQUE7O0FBR0osZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTs7QUFHSixlQUFDO0FBQ0QsZUFBQztFQUNHLHlCQUFBO0VBQ0Esc0JBQUE7O0FBR0osZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErRko7QUFDQSxhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTs7QUFHSixhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBOztBQUdKLGFBQUM7QUFDRCxhQUFDO0VBQ0cseUJBQUE7RUFDQSxzQkFBQTs7QUFHSixhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQWtDSjtBQUFBLElBRkE7QUFHQSxjQUFDO0FBQUQsSUFIQSxVQUdDO0FBQ0QsY0FBQztBQUFELElBSkEsVUFJQztBQUNELGNBQUM7QUFBRCxJQUxBLFVBS0M7QUFDRCxjQUFDO0FBQUQsSUFOQSxVQU1DO0FBQ0QsY0FBQztBQUFELElBUEEsVUFPQztBQUNELGNBQUM7QUFBRCxJQVJBLFVBUUM7QUFDRCxjQUFDO0FBQUQsSUFUQSxVQVNDO0FBQ0QsY0FBQztBQUFELElBVkEsVUFVQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTtFQUNBLGVBQUE7RUFDQSxtQkFBQTs7QUFHSixjQUFDO0FBQUQsSUFqQkEsVUFpQkM7QUFDRCxjQUFDO0FBQUQsSUFsQkEsVUFrQkM7RUFDRyxzQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFrQ1I7RUFFSSxrQ0FBQTtFQUdBLGtCQUFBOztBQUVBLFdBQUU7RUFDRSx5QkFBQTs7QUFLUixPQUlJLE9BQU07QUFKVixPQUtJLE1BQUs7RUFDRCx5QkFBQTtFQUNBLDRCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvSFI7RUFDSSx3QkFBQTtFQUNBLCtCQUFBO0VBQ0EsZ0RBQUE7RUFDQSxzQkFBQTs7QUFFQSxlQUFnQjtFQUNaLDJCQUFBO0VBQ0EsNENBQUE7O0FBRUosYUFBYztFQUNWLDJCQUFBO0VBQ0EsNENBQUE7O0FBRUosY0FBZTtBQUNmLElBQUksVUFBVztFQUNYLDJCQUFBO0VBQ0EsNENBQUE7O0FBSVI7RUFDSSx3QkFBQTtFQUNBLGVBQUE7RUFDQSw4QkFBQTtFQUNBLCtDQUFBO0VBQ0Esc0JBQUE7O0FBRUEsZUFBZ0I7RUFDWiwwQkFBQTtFQUNBLDJDQUFBOztBQUVKLGFBQWM7RUFDViwwQkFBQTtFQUNBLDJDQUFBOztBQUVKLGNBQWU7QUFDZixJQUFJLFVBQVc7RUFDWCwwQkFBQTtFQUNBLDJDQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEyQ1I7RUFVUSxnQkFBQTs7QUFOSixhQUFDO0VBQ0csMEJBQUE7RUFDQSw2QkFBQTs7QUFPSixhQUFDO0VBQ0cseUJBQUE7RUFDQSw0QkFBQTs7QUFLSixhQUFDLE1BQU87QUFDUixhQUFDLE1BQU8sZ0JBQUc7QUFDWDtBQUNBLGFBQUU7QUFDRixhQUFDO0FBQ0QsYUFBRSxnQkFBRztFQUNELHNCQUFBOztBQUdKLGFBQUMsTUFBTSxXQUFZLGdCQUFHO0FBQ3RCLGFBQUMsTUFBTSxXQUFZLGdCQUFHLEtBQUs7QUFDM0IsYUFBQztBQUNELGFBQUMsS0FBSztBQUNOLGFBQUMsV0FBWSxnQkFBRztBQUNoQixhQUFDLFdBQVksZ0JBQUcsS0FBSztFQUNqQiwwQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBd0ZKO0FBQ0EscUJBQUM7QUFDRCxxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDO0FBQ0QscUJBQUM7QUFDRCxxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDO0VBQ0cseUJBQUE7O0FBR0oscUJBQUMsZUFBZTtBQUNoQixxQkFBQyxlQUFlO0FBQ2hCLHFCQUFDLGVBQWU7RUFDWix5QkFBQTs7QUFHSixxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDLGFBQWE7QUFDZCxxQkFBQyxhQUFhO0FBQ2QscUJBQUMsYUFBYTtFQUNWLHlCQUFBOztBQUdKLHFCQUFDO0FBQ0QscUJBQUMsY0FBYztBQUNmLHFCQUFDLGNBQWM7QUFDZixxQkFBQyxjQUFjO0FBQ2YscUJBQUM7QUFDRCxxQkFBQyxVQUFVO0FBQ1gscUJBQUMsVUFBVTtBQUNYLHFCQUFDLFVBQVU7RUFDUCx5QkFBQTs7QUFHSixxQkFBQztFQUNHLDBCQUFBO0VBQ0EsMkJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBcUNSO0VBRUksVUFBQTtFQUNBLGlDQUFBO0VBQ0EsZ0JBQUE7RUFHQSxlQUFBOztBQUVBO0FBQ0EsVUFBQztBQUNELFVBQUM7RUFDRyw0QkFBQTtFQUNBLDZCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQUFDO0FBQ0QsVUFBQztFQUNHLGdDQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBQUM7QUFDRCxVQUFDO0VBQ0csMEJBQUE7RUFDQSw2QkFBQTtFQUNBLDRCQUFBOztBQUdKLFVBQUM7QUFDRCxVQUFDO0VBQ0csZ0NBQUE7RUFDQSw2QkFBQTtFQUNBLGNBQUE7O0FBS1IsT0FFSSxPQUFNO0FBRlYsT0FHSSxNQUFLO0VBQ0QsVUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1Q0osVUFGTTtBQUdOLFVBSE0sZUFHTDtBQUNELFVBSk0sZUFJTDtFQUNHLDRCQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBVk0sZUFVTDtBQUNELFVBWE0sZUFXTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQWhCTSxlQWdCTDtBQUNELFVBakJNLGVBaUJMO0VBQ0csc0JBQUE7O0FBR0osVUFyQk0sZUFxQkw7QUFDRCxVQXRCTSxlQXNCTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1Q0osVUFGTTtBQUdOLFVBSE0sYUFHTDtBQUNELFVBSk0sYUFJTDtFQUNHLDRCQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBVk0sYUFVTDtBQUNELFVBWE0sYUFXTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQWhCTSxhQWdCTDtBQUNELFVBakJNLGFBaUJMO0VBQ0csc0JBQUE7O0FBR0osVUFyQk0sYUFxQkw7QUFDRCxVQXRCTSxhQXNCTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUM5OEJSO0VKV0kscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBOElBLG1CQUFBO0VBQ0EseUJBQUE7RUFPQSxhQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLHVCQUFBO0VJdEtBLDJCQUFBOztBSllBLE9BQVE7RUFDSiw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7O0FJTUosYUFBQztBQUNELGFBQUM7QUFDRCxhQUFDO0FBQ0QsYUFBQztBQUNELGFBQUM7QUFDRCxhQUFDO0VBQ0cscUJBQUE7RUFDQSxrQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErQ0osS0FSQyxhQVFBO0FBQUQsS0FQQyxlQU9BO0FBQUQsS0FOQyxjQU1BO0FBQUQsS0FMQyxZQUtBO0FBQUQsS0FKQyxZQUlBO0FBQUQsS0FIQyxlQUdBO0FBQUQsTUFGRSxVQUVEO0FBQUQsUUFBQztFQUNHLHlCQUFBO0VBQ0EsMEJBQUE7O0FBRUosS0FaQyxhQVlBO0FBQUQsS0FYQyxlQVdBO0FBQUQsS0FWQyxjQVVBO0FBQUQsS0FUQyxZQVNBO0FBQUQsS0FSQyxZQVFBO0FBQUQsS0FQQyxlQU9BO0FBQUQsTUFORSxVQU1EO0FBQUQsUUFBQztFQUNHLHlCQUFBO0VBQ0EsMEJBQUE7O0FBRUosS0FoQkMsYUFnQkE7QUFBRCxLQWZDLGVBZUE7QUFBRCxLQWRDLGNBY0E7QUFBRCxLQWJDLFlBYUE7QUFBRCxLQVpDLFlBWUE7QUFBRCxLQVhDLGVBV0E7QUFBRCxNQVZFLFVBVUQ7QUFBRCxRQUFDO0VBQ0cseUJBQUE7RUFDQSwwQkFBQTs7QUFFSixLQXBCQyxhQW9CQTtBQUFELEtBbkJDLGVBbUJBO0FBQUQsS0FsQkMsY0FrQkE7QUFBRCxLQWpCQyxZQWlCQTtBQUFELEtBaEJDLFlBZ0JBO0FBQUQsS0FmQyxlQWVBO0FBQUQsTUFkRSxVQWNEO0FBQUQsUUFBQztFQUNHLHlCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb0RSLENBQUM7RUFHRyxrQkFBQTtFQUNBLFVBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBQUdKLE1BQU8sSUFBRztFQUNOLGNBQUE7O0FBR0osUUFBUyxJQUFHO0VBQ1IsY0FBQTs7QUFHSixRQUFTLElBQUc7RUFDUixjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBcUZKLFdBQVk7RUFDUixtQkFBQTs7QUFHSixnQkFBaUI7RUFDYixvQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUxqUEoscUJBSDBDO0VBRzFDO0lNNFFFLGNBQUE7SUFDQSxrQkFBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7OztBRFFFLGVBQUM7RUFDRyx1QkFBQTs7QUx4UlIscUJBSDBDO0VBRzFDLGVLdVJLO0lDak9ILHFCQUFBO0lBQ0EsOEJBQUE7SUFDRywyQkFBQTtJQUNLLHNCQUFBO0lBWVIseUJBQUE7SUFDQSxvQkFBQTtJQUdBLHFCQUFBO0lBRUEsbUJBQUE7SUE4QkUsVUFBQTtJRGtMUSxxQkFBQTs7RUM5TVYsT0FBUSxnQkQwTUw7SUN4TUQsZUFBQTtJQUdBLGVBQUE7SUFHQSxPQUFBO0lBRUEsY0FBYywwQ0FBZDs7O0FOdkZKLHFCQUgwQztFQUcxQyxlS3VSSztJQ2pPSCxxQkFBQTtJQUNBLDhCQUFBO0lBQ0csMkJBQUE7SUFDSyxzQkFBQTtJQVlSLHlCQUFBO0lBQ0Esb0JBQUE7SUFHQSxxQkFBQTtJQUVBLG1CQUFBO0lBOEJFLG1CQUFBO0lEc0xRLHFCQUFBOztFQ2xOVixPQUFRLGdCRDBNTDtJQ3hNRCxlQUFBO0lBR0EsZUFBQTtJQUdBLE9BQUE7SUFFQSxjQUFjLDBDQUFkOzs7QURnTUEsZUFBQyxNQVdHO0VBQ0ksc0JBQUE7RUFDQSxXQUFBOztBQUlSLGVBQUM7RUFDRyx1QkFBQTs7QUx6U1IscUJBSDBDO0VBRzFDLGVLd1NLO0lDbFBILHFCQUFBO0lBQ0EsOEJBQUE7SUFDRywyQkFBQTtJQUNLLHNCQUFBO0lBWVIseUJBQUE7SUFDQSxvQkFBQTtJQUdBLHFCQUFBO0lBRUEsbUJBQUE7SUE4QkUsVUFBQTs7RUE1QkYsT0FBUSxnQkQyTkw7SUN6TkQsZUFBQTtJQUdBLGVBQUE7SUFHQSxPQUFBO0lBRUEsY0FBYywwQ0FBZDs7O0FOdkZKLHFCQUgwQztFQUcxQyxlS3dTSztJQ2xQSCxxQkFBQTtJQUNBLDhCQUFBO0lBQ0csMkJBQUE7SUFDSyxzQkFBQTtJQVlSLHlCQUFBO0lBQ0Esb0JBQUE7SUFHQSxxQkFBQTtJQUVBLG1CQUFBO0lBOEJFLG1CQUFBOztFQTVCRixPQUFRLGdCRDJOTDtJQ3pORCxlQUFBO0lBR0EsZUFBQTtJQUdBLE9BQUE7SUFFQSxjQUFjLDBDQUFkOzs7QURpTkEsZUFBQyxJQVVHO0VBQ0ksc0JBQUE7RUFDQSxXQUFBOztBQVpSLGVBQUMsSUFlRztFQUNJLDBCQUFBO0VBQ0EsMkJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9DWjtFQUVJLGtCQUFBOztBQUZKLGlCQUlJLE1BQUs7QUFKVCxpQkFLSSxNQUFLO0FBTFQsaUJBTUksTUFBSztBQU5ULGlCQU9JLE1BQUs7QUFQVCxpQkFRSSxNQUFLO0FBUlQsaUJBU0ksTUFBSztFQUNELHNCQUFBO0VBQ0EsV0FBQTtFQUNBLHVCQUFBOztBQUVBLGlCQVZKLE1BQUssYUFVQTtBQUFELGlCQVRKLE1BQUssZUFTQTtBQUFELGlCQVJKLE1BQUssY0FRQTtBQUFELGlCQVBKLE1BQUssWUFPQTtBQUFELGlCQU5KLE1BQUssWUFNQTtBQUFELGlCQUxKLE1BQUssZUFLQTtFQUNHLGtCQUFBOztBQWZaLGlCQW1CSTtFTmlDQSxpQ0FBQTtFTS9CSSxrQkFBQTtFQUNBLGVBQUE7RUFDQSxNQUFBOzs7QUFFQSxpQkFOSixLQU1LO0VBQ0csbUJBQUE7O0FBSUosaUJBWEosS0FXSyxNQUFNO0VBQ0gsc0JBQUEifQ== */
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1jc3Mvbm9ybWFsaXplLmNzcyIsIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1sZWdhY3ktYWRkb24vbm9ybWFsaXplLWxlZ2FjeS1hZGRvbi5jc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtdXRpbGl0aWVzLmxlc3MiLCIvc3JjL3ZlbmRvci9jZi1jb3JlL3NyYy9jZi11dGlsaXRpZXMubGVzcyIsIi8uLi9jZi1jb3JlL3NyYy9jZi1tZWRpYS1xdWVyaWVzLmxlc3MiLCIvc3JjL3ZlbmRvci9jZi1jb3JlL3NyYy9jZi1tZWRpYS1xdWVyaWVzLmxlc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtYmFzZS5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtY29yZS9zcmMvY2YtYmFzZS5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtY29yZS9zcmMvY2YtdmFycy5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtaWNvbnMvc3JjL2NmLWljb25zLmxlc3MiLCIvLi4vY2YtYnV0dG9ucy9zcmMvY2YtYnV0dG9ucy5sZXNzIiwiL3NyYy9jZi1mb3Jtcy5sZXNzIiwiLy4uL2NmLWdyaWQvc3JjL2NmLWdyaWQubGVzcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOzs7Ozs7QUFRQTtFQUNFLHVCQUFBOztFQUNBLDBCQUFBOztFQUNBLDhCQUFBOzs7Ozs7QUFPRjtFQUNFLFNBQUE7Ozs7Ozs7Ozs7QUFhRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNFLGNBQUE7Ozs7OztBQVFGO0FBQ0E7QUFDQTtBQUNBO0VBQ0UscUJBQUE7O0VBQ0Esd0JBQUE7Ozs7Ozs7QUFRRixLQUFLLElBQUk7RUFDUCxhQUFBO0VBQ0EsU0FBQTs7Ozs7O0FBUUY7QUFDQTtFQUNFLGFBQUE7Ozs7Ozs7QUFVRjtFQUNFLDZCQUFBOzs7Ozs7QUFRRixDQUFDO0FBQ0QsQ0FBQztFQUNDLFVBQUE7Ozs7Ozs7QUFVRixJQUFJO0VBQ0YseUJBQUE7Ozs7O0FBT0Y7QUFDQTtFQUNFLGlCQUFBOzs7OztBQU9GO0VBQ0Usa0JBQUE7Ozs7OztBQVFGO0VBQ0UsY0FBQTtFQUNBLGdCQUFBOzs7OztBQU9GO0VBQ0UsZ0JBQUE7RUFDQSxXQUFBOzs7OztBQU9GO0VBQ0UsY0FBQTs7Ozs7QUFPRjtBQUNBO0VBQ0UsY0FBQTtFQUNBLGNBQUE7RUFDQSxrQkFBQTtFQUNBLHdCQUFBOztBQUdGO0VBQ0UsV0FBQTs7QUFHRjtFQUNFLGVBQUE7Ozs7Ozs7QUFVRjtFQUNFLFNBQUE7Ozs7O0FBT0YsR0FBRyxJQUFJO0VBQ0wsZ0JBQUE7Ozs7Ozs7QUFVRjtFQUNFLGdCQUFBOzs7OztBQU9GO0VBQ0UsdUJBQUE7RUFDQSxTQUFBOzs7OztBQU9GO0VBQ0UsY0FBQTs7Ozs7QUFPRjtBQUNBO0FBQ0E7QUFDQTtFQUNFLGlDQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7QUFrQkY7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNFLGNBQUE7O0VBQ0EsYUFBQTs7RUFDQSxTQUFBOzs7Ozs7QUFPRjtFQUNFLGlCQUFBOzs7Ozs7OztBQVVGO0FBQ0E7RUFDRSxvQkFBQTs7Ozs7Ozs7O0FBV0Y7QUFDQSxJQUFLLE1BQUs7QUFDVixLQUFLO0FBQ0wsS0FBSztFQUNILDBCQUFBOztFQUNBLGVBQUE7Ozs7OztBQU9GLE1BQU07QUFDTixJQUFLLE1BQUs7RUFDUixlQUFBOzs7OztBQU9GLE1BQU07QUFDTixLQUFLO0VBQ0gsU0FBQTtFQUNBLFVBQUE7Ozs7OztBQVFGO0VBQ0UsbUJBQUE7Ozs7Ozs7OztBQVdGLEtBQUs7QUFDTCxLQUFLO0VBQ0gsc0JBQUE7O0VBQ0EsVUFBQTs7Ozs7Ozs7QUFTRixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0VBQ2xCLFlBQUE7Ozs7OztBQVFGLEtBQUs7RUFDSCw2QkFBQTs7RUFDQSx1QkFBQTs7Ozs7Ozs7QUFTRixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0VBQ2xCLHdCQUFBOzs7OztBQU9GO0VBQ0UseUJBQUE7RUFDQSxhQUFBO0VBQ0EsOEJBQUE7Ozs7OztBQVFGO0VBQ0UsU0FBQTs7RUFDQSxVQUFBOzs7Ozs7QUFPRjtFQUNFLGNBQUE7Ozs7OztBQVFGO0VBQ0UsaUJBQUE7Ozs7Ozs7QUFVRjtFQUNFLHlCQUFBO0VBQ0EsaUJBQUE7O0FBR0Y7QUFDQTtFQUNFLFVBQUE7Ozs7Ozs7OztBQzVaRjtBQUNBO0FBQ0E7RUFDSSxnQkFBQTtFQUNBLFFBQUE7Ozs7Ozs7OztBQVlKO0VBQ0ksZUFBQTs7Ozs7O0FBUUo7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNJLHVCQUFBOzs7Ozs7Ozs7O0FBYUo7RUFDSSxnQkFBQTs7QUFHSjtFQUNJLGdCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDSSxpQkFBQTtFQUNBLGFBQUE7O0FBR0o7RUFDSSxjQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDSSxpQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0ksaUJBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGdCQUFBOzs7OztBQU9KO0FBQ0E7RUFDSSxhQUFBOzs7OztBQU9KO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksY0FBYyx3QkFBZDs7Ozs7QUFPSjtFQUNJLGdCQUFBO0VBQ0EscUJBQUE7Ozs7O0FBT0o7RUFDSSxZQUFBOzs7OztBQU9KLENBQUM7QUFDRCxDQUFDO0VBQ0csU0FBUyxFQUFUO0VBQ0EsYUFBQTs7Ozs7Ozs7QUFXSjtBQUNBO0FBQ0E7QUFDQTtFQUNJLGFBQUE7O0FBR0o7RUFDSSxrQkFBQTs7Ozs7QUFPSjtBQUNBO0FBQ0E7RUFDSSxtQkFBQTs7Ozs7QUFPSixHQUFJO0FBQ0osR0FBSTtFQUNBLGdCQUFBO0VBQ0Esc0JBQUE7Ozs7Ozs7O0FBV0o7RUFDSSwrQkFBQTs7Ozs7Ozs7QUFXSjtFQUNJLFNBQUE7Ozs7Ozs7QUFTSjtFQUNJLFNBQUE7O0VBQ0EsbUJBQUE7O0VBQ0Esa0JBQUE7Ozs7OztBQU9KO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksd0JBQUE7RUFDQSx1QkFBQTs7Ozs7O0FBUUo7QUFDQSxJQUFLLE1BQUs7QUFDVixLQUFLO0FBQ0wsS0FBSztFQUNELGtCQUFBOzs7Ozs7QUFRSixLQUFLO0FBQ0wsS0FBSztFQUNELGFBQUE7RUFDQSxZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQzlNQSxNQUFPO0VBQ0gsd0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBeUJKLFdBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTs7QUFFSixPQUFRO0VBQ0osT0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTBCUjtFQUNFLGtCQUFBO0VBQ0EsVUFBQTtFQUNBLFdBQUE7RUFDQSxTQUFBO0VBQ0EsWUFBQTtFQUNBLFVBQUE7RUFDQSxnQkFBQTtFQUNBLE1BQU0sYUFBTjs7Ozs7Ozs7Ozs7Ozs7QUFpQkY7RUFDSSxxQkFBQTs7QUFDQSxPQUFRO0VBRUosZUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF3QlI7RUFDSSxZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvQ0o7RUFDSSxxQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbUhKO0VDTEksa0JBQUE7RUFDQSxzQkFBQTtFQUNBLFNBQUE7O0FET0o7RUFDSSxrQkFBQTtFQUNBLE1BQUE7RUFDQSxPQUFBO0VBQ0EsV0FBQTtFQUNBLFlBQUE7O0FBR0o7RUNqQkksa0JBQUE7RUFDQSxtQkFBQTtFQUNBLFNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FEb05KO0VBQVUsd0JBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDBCQUFBOztBQUNWO0VBQVUsNkJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMERWO0VBQWEsV0FBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsbUJBQUE7O0FBQ2I7RUFBYSxtQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUVqZ0JiLHFCQUgwQztFQUcxQztJRndpQlEsYUFBQTs7O0FHeGlCUixxQkFIMEM7RUFHMUM7SUh3aUJRLGFBQUE7OztBQUlSO0VBQ0ksYUFBQTs7QUU3aUJKLHFCQUgwQztFQUcxQztJRitpQlEsY0FBQTs7O0FHL2lCUixxQkFIMEM7RUFHMUM7SUgraUJRLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbURSO0VDSEUsa0JBQUE7O0FET0Y7RUNQRSxrQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBR3hpQkY7RUFDSSxjQUFBO0VBQ0Esc0JBQXNCLHdCQUF0QjtFQUNBLGVBQUE7RUFDQSxrQkFBQTs7QUE4REo7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTs7QUFHSjtBQUNBO0VDeEtJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEckdBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRHFJSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0VBQ1Asd0JBQUE7O0FGOUlSLHFCQUgwQztFQUcxQztFQUFBO0lHckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQThHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEOUdBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRG1KQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7O0VBR0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7SUFDQSx3QkFBQTs7O0FEektaLHFCQUgwQztFQUcxQztFQUFBO0lFckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQThHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEOUdBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRG1KQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7O0VBR0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7SUFDQSx3QkFBQTs7O0FBS1o7QUFDQTtFQ3BOSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUE4R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRDlHQSxFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FEbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURpTEosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztFQUNQLHdCQUFBOztBQUdKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0Esd0JBQUE7O0FGdk1SLHFCQUgwQztFQUcxQztFQUFBO0lHckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQXVIQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEdkhBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRDRNQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7OztBRHJOWixxQkFIMEM7RUFHMUM7RUFBQTtJRXJDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUF1SEEsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHZIQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUQ0TUEsQ0FBRTtFQUFGLENBQUU7RUFDRixFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxNQUFPO0VBQVAsTUFBTztFQUNQLEdBQUk7RUFBSixHQUFJO0VBQ0osS0FBTTtFQUFOLEtBQU07RUFDTixVQUFXO0VBQVgsVUFBVztJQUNQLHdCQUFBOzs7QUFLWjtBQUNBO0VDaFFJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXVIQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEdkhBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRDZOSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0FBQ1gsRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSx3QkFBQTs7QUZoUFIscUJBSDBDO0VBRzFDO0VBQUE7SUdaSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsZ0JBQUE7SUF1R0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHhHQSxPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VEREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RUNESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOzs7QUZRUixxQkFIMEM7RUFHMUM7RUFBQTtJRVpJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxnQkFBQTtJQXVHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEeEdBLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VDREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RURESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7OztBRGdRUjtBQUNBO0VDclFJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTtFQXVHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEeEdBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEb1FKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBQUlSO0FBQ0E7RUN0UkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEMUdBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEcVJKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBQUlSO0FBQ0E7RUNoVEkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBa0hBLHFCQUFBO0VBQ0EsaUJBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEckhBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEK1NKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLGlCQUFBOztBQUlSO0FBY0E7QUNBQTtFQXpYSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUF1SEEsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VEbVBBLHdCQUFBO0VBQ0EsMkJBQUE7O0FBM1dBLGVBQUU7QUFDRixlQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxnQkRmTjtBQ2VGLE9BQVEsZ0JEZE47RUNlRSw2QkFBQTs7QURYSixlQUFFO0FBQ0YsZUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxnQkQ1Qk47QUM0QkYsT0FBUSxnQkQzQk47RUM0QkUsOEJBQUE7O0FBbENKLGVBQUU7QUFDRixlQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JDZk47QURlRixPQUFRLGdCQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUFYSixlQUFFO0FBQ0YsZUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkM1Qk47QUQ0QkYsT0FBUSxnQkMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FEbENKLGVBQUU7QUFDRixlQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxnQkRmTjtBQ2VGLE9BQVEsZ0JEZE47RUNlRSw2QkFBQTs7QURYSixlQUFFO0FBQ0YsZUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxnQkQ1Qk47QUM0QkYsT0FBUSxnQkQzQk47RUM0QkUsOEJBQUE7O0FBbENKLGVBQUU7QUFDRixlQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JDZk47QURlRixPQUFRLGdCQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUFYSixlQUFFO0FBQ0YsZUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkM1Qk47QUQ0QkYsT0FBUSxnQkMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FIRFIscUJBSDBDO0VBRzFDO0VFb1ZBO0VDQUE7SUROUSx3QkFBQTtJQUNBLGtCQUFBOzs7QUQvVVIscUJBSDBDO0VBRzFDO0VDb1ZBO0VDQUE7SUROUSx3QkFBQTtJQUNBLGtCQUFBOzs7QUFTUjtBQVlBO0FDQUE7RUF6WUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VEaVlBLDJCQUFBO0VBQ0EsY0FBQTtFQUNBLGlCQUFBOztBQWpZQSxhQUFFO0FBQ0YsYUFBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGNBZk47QUFlRixPQUFRLGNBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLGNEZk47QUNlRixPQUFRLGNEZE47RUNlRSw2QkFBQTs7QURYSixhQUFFO0FBQ0YsYUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxjQTVCTjtBQTRCRixPQUFRLGNBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsY0Q1Qk47QUM0QkYsT0FBUSxjRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osYUFBRTtBQUNGLGFBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxjQ2ZOO0FEZUYsT0FBUSxjQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxjQWZOO0FBZUYsT0FBUSxjQWROO0VBZUUsNkJBQUE7O0FBWEosYUFBRTtBQUNGLGFBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsY0M1Qk47QUQ0QkYsT0FBUSxjQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLGNBNUJOO0FBNEJGLE9BQVEsY0EzQk47RUE0QkUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRCtYUjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNJLGFBQUE7RUFDQSx1QkFBQTs7QUFHSixDQUFFO0FBQ0YsQ0FBRTtFQUNFLHFCQUFBOztBQUdKLElBQUksS0FBTTtFQUNOLG9CQUFBOztBQUlKLE9BQVEsSUFBSTtFQUNSLGdCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE4Qko7RUFDSSxlQUFBO0VBQ0Esb0JBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7RUFDQSxxQkFBQTs7QUFFQSxDQUFDO0FBQ0QsQ0FBQztFQUNHLHFCQUFBO0VBQ0EsY0FBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxvQkFBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzRVIsQ0FLSTtBQUpKLEVBSUk7QUFISixFQUdJO0VBQ0ksd0JBQUE7O0FBSVIsR0FBSTtFQUVBLHNCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBNEJKO0VBR0ksaUJBQUE7RUFDQSxrQkFBQTs7QUFJSjtFQUNJLHNCQUFBOztBQURKLEVBR0k7RUFDSSxzQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXlDUjtFQzFwQkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtBQUU7QUFDRixLQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTURmTjtBQ2VGLE9BQVEsTURkTjtFQ2VFLDZCQUFBOztBRFhKLEtBQUU7QUFDRixLQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxNRDVCTjtBQzRCRixPQUFRLE1EM0JOO0VDNEJFLDhCQUFBOztBQWxDSixLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZk47QURlRixPQUFRLE1DZE47RURlRSw2QkFBQTs7QUNESixPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzVCTjtBRDRCRixPQUFRLE1DM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUR3bkJSO0FBQ0E7RUFDSSxnQkFBQTs7QUFFQSxLQUFNO0FBQU4sS0FBTTtFQUNGLGNBQUE7RUFDQSxtQkFBQTtFQ2xvQkoscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEMUdBLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FDREosT0FBUSxNRDZuQkY7QUM3bkJOLE9BQVEsTUQ2bkJGO0VDNW5CRiw4QkFBQTs7QURESixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUQ2bkJGO0FDN25CTixPQUFRLE1ENm5CRjtFQzVuQkYsOEJBQUE7O0FEcVJKLENBQUUsUUF1V0k7QUF2V04sQ0FBRSxRQXVXSTtBQXRXTixFQUFHLFFBc1dHO0FBdFdOLEVBQUcsUUFzV0c7QUFyV04sRUFBRyxRQXFXRztBQXJXTixFQUFHLFFBcVdHO0FBcFdOLEVBQUcsUUFvV0c7QUFwV04sRUFBRyxRQW9XRztBQW5XTixNQUFPLFFBbVdEO0FBbldOLE1BQU8sUUFtV0Q7QUFsV04sR0FBSSxRQWtXRTtBQWxXTixHQUFJLFFBa1dFO0FBaldOLEtBQU0sUUFpV0E7QUFqV04sS0FBTSxRQWlXQTtBQWhXTixVQUFXLFFBZ1dMO0FBaFdOLFVBQVcsUUFnV0w7QUEvVk4sRUFBRyxRQStWRztBQS9WTixFQUFHLFFBK1ZHO0FBOVZOLEdBQUksUUE4VkU7QUE5Vk4sR0FBSSxRQThWRTtBQTdWTixFQUFHLFFBNlZHO0FBN1ZOLEVBQUcsUUE2Vkc7QUE1Vk4sR0FBSSxRQTRWRTtBQTVWTixHQUFJLFFBNFZFO0FBM1ZOLEVBQUcsUUEyVkc7QUEzVk4sRUFBRyxRQTJWRztBQTFWTixHQUFJLFFBMFZFO0FBMVZOLEdBQUksUUEwVkU7QUF6Vk4sRUFBRyxRQXlWRztBQXpWTixFQUFHLFFBeVZHO0FBeFZOLEdBQUksUUF3VkU7QUF4Vk4sR0FBSSxRQXdWRTtBQXZWTixFQUFHLFFBdVZHO0FBdlZOLEVBQUcsUUF1Vkc7QUF0Vk4sR0FBSSxRQXNWRTtBQXRWTixHQUFJLFFBc1ZFO0VBclZGLHdCQUFBOztBQXhTSixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUQ2bkJGO0FDN25CTixPQUFRLE1ENm5CRjtFQzVuQkYsOEJBQUE7O0FEREosT0FBUSxNQTZuQkY7QUE3bkJOLE9BQVEsTUE2bkJGO0VBNW5CRiw4QkFBQTs7QUNESixPQUFRLE1ENm5CRjtBQzduQk4sT0FBUSxNRDZuQkY7RUM1bkJGLDhCQUFBOztBQXFSSixDQUFFLFFEdVdJO0FDdldOLENBQUUsUUR1V0k7QUN0V04sRUFBRyxRRHNXRztBQ3RXTixFQUFHLFFEc1dHO0FDcldOLEVBQUcsUURxV0c7QUNyV04sRUFBRyxRRHFXRztBQ3BXTixFQUFHLFFEb1dHO0FDcFdOLEVBQUcsUURvV0c7QUNuV04sTUFBTyxRRG1XRDtBQ25XTixNQUFPLFFEbVdEO0FDbFdOLEdBQUksUURrV0U7QUNsV04sR0FBSSxRRGtXRTtBQ2pXTixLQUFNLFFEaVdBO0FDaldOLEtBQU0sUURpV0E7QUNoV04sVUFBVyxRRGdXTDtBQ2hXTixVQUFXLFFEZ1dMO0FDL1ZOLEVBQUcsUUQrVkc7QUMvVk4sRUFBRyxRRCtWRztBQzlWTixHQUFJLFFEOFZFO0FDOVZOLEdBQUksUUQ4VkU7QUM3Vk4sRUFBRyxRRDZWRztBQzdWTixFQUFHLFFENlZHO0FDNVZOLEdBQUksUUQ0VkU7QUM1Vk4sR0FBSSxRRDRWRTtBQzNWTixFQUFHLFFEMlZHO0FDM1ZOLEVBQUcsUUQyVkc7QUMxVk4sR0FBSSxRRDBWRTtBQzFWTixHQUFJLFFEMFZFO0FDelZOLEVBQUcsUUR5Vkc7QUN6Vk4sRUFBRyxRRHlWRztBQ3hWTixHQUFJLFFEd1ZFO0FDeFZOLEdBQUksUUR3VkU7QUN2Vk4sRUFBRyxRRHVWRztBQ3ZWTixFQUFHLFFEdVZHO0FDdFZOLEdBQUksUURzVkU7QUN0Vk4sR0FBSSxRRHNWRTtFQ3JWRix3QkFBQTs7QUQ0VlI7QUFDQSxLQUFNO0VBQ0YsZ0NBQUE7O0FBR0o7RUM1b0JJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFRDRvQkEsZ0JBQUE7O0FBM29CQSxPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtFQUNKLDhCQUFBOztBRDZvQlIsS0FBTTtFQ25yQkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtBK3FCRSxHQS9xQkE7QUFDRixLQThxQkUsR0E5cUJBO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFncUJOLEdBL3FCQTtBQWVGLE9BQVEsTUFncUJOLEdBOXFCQTtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTURncUJOLEdBL3FCQTtBQ2VGLE9BQVEsTURncUJOLEdBOXFCQTtFQ2VFLDZCQUFBOztBRFhKLEtBMHFCRSxHQTFxQkE7QUFDRixLQXlxQkUsR0F6cUJBO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BOG9CTixHQTFxQkE7QUE0QkYsT0FBUSxNQThvQk4sR0F6cUJBO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsTUQ4b0JOLEdBMXFCQTtBQzRCRixPQUFRLE1EOG9CTixHQXpxQkE7RUM0QkUsOEJBQUE7O0FBbENKLEtEK3FCRSxHQy9xQkE7QUFDRixLRDhxQkUsR0M5cUJBO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFncUJOLEdDL3FCQTtBRGVGLE9BQVEsTUFncUJOLEdDOXFCQTtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsTURncUJOLEdDL3FCQTtBQWVGLE9BQVEsTURncUJOLEdDOXFCQTtFQWVFLDZCQUFBOztBQVhKLEtEMHFCRSxHQzFxQkE7QUFDRixLRHlxQkUsR0N6cUJBO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BOG9CTixHQzFxQkE7QUQ0QkYsT0FBUSxNQThvQk4sR0N6cUJBO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUQ4b0JOLEdDMXFCQTtBQTRCRixPQUFRLE1EOG9CTixHQ3pxQkE7RUE0QkUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRDJxQlI7RUFDSSxzQkFBQTtFQUNBLHFCQUFBOztBRnJyQkoscUJBSDBDO0VBRzFDO0lFd3JCUSxxQkFBQTtJQUNBLG9CQUFBOzs7QUR6ckJSLHFCQUgwQztFQUcxQztJQ3dyQlEscUJBQUE7SUFDQSxvQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTRCUjtFQUNJLGNBQUE7RUFFQSx1QkFBQTtFQ3R2QkEscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtBQUU7QUFDRixLQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTURmTjtBQ2VGLE9BQVEsTURkTjtFQ2VFLDZCQUFBOztBRFhKLEtBQUU7QUFDRixLQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxNRDVCTjtBQzRCRixPQUFRLE1EM0JOO0VDNEJFLDhCQUFBOztBQWxDSixLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZk47QURlRixPQUFRLE1DZE47RURlRSw2QkFBQTs7QUNESixPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzVCTjtBRDRCRixPQUFRLE1DM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUQ2c0JSLEtBTUksTUFBSztBQU5ULEtBT0ksTUFBSztFQUNELHFCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBdUVSLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMO0FBQ0EsTUFBTTtFQUdGLHFCQUFBO0VBQ0EsU0FBQTtFQUNBLGdCQUFBO0VBQ0EsOEJBQUE7RUFDQSxjQUFBO0VBQ0EsbUJBQUE7RUFDQSx5QkFBQTtFQUNBLGdCQUFBO0VBQ0EsbUJBQUE7RUFDQSx3QkFBQTtFQUNBLDhDQUFBOztBQUtKO0VBQ0ksd0JBQUE7O0FBS0osS0FBSyxhQUFhO0FBQ2xCLEtBQUssYUFBYTtBQUNsQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssY0FBYztBQUNuQixLQUFLLGNBQWM7QUFDbkIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7QUFDcEIsUUFBUTtBQUNSLFFBQVE7QUFDUixNQUFNLFVBQVU7QUFDaEIsTUFBTSxVQUFVO0VBQ1oseUJBQUE7RUFDQSwwQkFBQTtFQUNBLGlCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDRyxPRWgwQjZCLGtCRmcwQjdCOztBQUVIO0VBQ0csT0VuMEI2QixrQkZtMEI3Qjs7QUFFSDtFQUNHLE9FdDBCNkIsa0JGczBCN0I7Ozs7Ozs7Ozs7Ozs7O0FBaUJIO0VBQ0ksZUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNCSjtFQUNJLGNBQUE7RUFDQSxlQUFBOztBQUZKLE1BSUk7RUFFSSxzQkFBQTs7QUFJUixpQkFBa0I7RUFDZCx5QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBSDE3QkEsTUFBTztFQUNILHdCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXlCSixXQUFDO0VBQ0csU0FBUyxFQUFUO0VBQ0EsY0FBQTtFQUNBLFdBQUE7O0FBRUosT0FBUTtFQUNKLE9BQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEwQlI7RUFDRSxrQkFBQTtFQUNBLFVBQUE7RUFDQSxXQUFBO0VBQ0EsU0FBQTtFQUNBLFlBQUE7RUFDQSxVQUFBO0VBQ0EsZ0JBQUE7RUFDQSxNQUFNLGFBQU47Ozs7Ozs7Ozs7Ozs7O0FBaUJGO0VBQ0kscUJBQUE7O0FBQ0EsT0FBUTtFQUVKLGVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBd0JSO0VBQ0ksWUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb0NKO0VBQ0kscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW1ISjtFQUxJLGtCQUFBO0VBQ0Esc0JBQUE7RUFDQSxTQUFBOztBQU9KO0VBQ0ksa0JBQUE7RUFDQSxNQUFBO0VBQ0EsT0FBQTtFQUNBLFdBQUE7RUFDQSxZQUFBOztBQUdKO0VBakJJLGtCQUFBO0VBQ0EsbUJBQUE7RUFDQSxTQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9OSjtFQUFVLHdCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSwwQkFBQTs7QUFDVjtFQUFVLDZCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTBEVjtFQUFhLFdBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLG1CQUFBOztBQUNiO0VBQWEsbUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FDamdCYixxQkFIMEM7RUFHMUM7SUR3aUJRLGFBQUE7OztBRXhpQlIscUJBSDBDO0VBRzFDO0lGd2lCUSxhQUFBOzs7QUFJUjtFQUNJLGFBQUE7O0FDN2lCSixxQkFIMEM7RUFHMUM7SUQraUJRLGNBQUE7OztBRS9pQlIscUJBSDBDO0VBRzFDO0lGK2lCUSxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW1EUjtFQUhFLGtCQUFBOztBQU9GO0VBUEUsa0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUl4aUJGO0VBQ0ksY0FBQTtFQUNBLHNCQUFzQix3QkFBdEI7RUFDQSxlQUFBO0VBQ0Esa0JBQUE7O0FBOERKO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNJLGFBQUE7O0FBR0o7QUFDQTtFQXhLSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUFxR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRHJHQSxFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FEbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUFxSUosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztFQUNQLHdCQUFBOztBSDlJUixxQkFIMEM7RUFHMUM7RUFBQTtJR3JDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUE4R0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRDlHQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUFtSkEsQ0FBRTtFQUFGLENBQUU7RUFDRixFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxNQUFPO0VBQVAsTUFBTztFQUNQLEdBQUk7RUFBSixHQUFJO0VBQ0osS0FBTTtFQUFOLEtBQU07RUFDTixVQUFXO0VBQVgsVUFBVztJQUNQLHdCQUFBOztFQUdKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0lBQ0Esd0JBQUE7OztBRnpLWixxQkFIMEM7RUFHMUM7RUFBQTtJRXJDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUE4R0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRDlHQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUFtSkEsQ0FBRTtFQUFGLENBQUU7RUFDRixFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxNQUFPO0VBQVAsTUFBTztFQUNQLEdBQUk7RUFBSixHQUFJO0VBQ0osS0FBTTtFQUFOLEtBQU07RUFDTixVQUFXO0VBQVgsVUFBVztJQUNQLHdCQUFBOztFQUdKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0lBQ0Esd0JBQUE7OztBQUtaO0FBQ0E7RUFwTkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBOEdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUQ5R0EsRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRGxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FBaUxKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7RUFDUCx3QkFBQTs7QUFHSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBSHZNUixxQkFIMEM7RUFHMUM7RUFBQTtJR3JDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUF1SEEsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHZIQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUE0TUEsQ0FBRTtFQUFGLENBQUU7RUFDRixFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxNQUFPO0VBQVAsTUFBTztFQUNQLEdBQUk7RUFBSixHQUFJO0VBQ0osS0FBTTtFQUFOLEtBQU07RUFDTixVQUFXO0VBQVgsVUFBVztJQUNQLHdCQUFBOzs7QUZyTloscUJBSDBDO0VBRzFDO0VBQUE7SUVyQ0kscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBO0lBdUhBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUR2SEEsRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRGxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VBNE1BLENBQUU7RUFBRixDQUFFO0VBQ0YsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsTUFBTztFQUFQLE1BQU87RUFDUCxHQUFJO0VBQUosR0FBSTtFQUNKLEtBQU07RUFBTixLQUFNO0VBQ04sVUFBVztFQUFYLFVBQVc7SUFDUCx3QkFBQTs7O0FBS1o7QUFDQTtFQWhRSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUF1SEEsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRHZIQSxFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FEbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUE2TkosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztBQUNYLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0Esd0JBQUE7O0FIaFBSLHFCQUgwQztFQUcxQztFQUFBO0lHWkkscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGdCQUFBO0lBdUdBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUR4R0EsT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RUNESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFRERKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VDREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7O0FGUVIscUJBSDBDO0VBRzFDO0VBQUE7SUVaSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsZ0JBQUE7SUF1R0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHhHQSxPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VEREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RUNESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOzs7QUFnUVI7QUFDQTtFQXJRSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsZ0JBQUE7RUF1R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRHhHQSxPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQW9RSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0FBQ1gsRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSx3QkFBQTs7QUFJUjtBQUNBO0VBdFJJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQXVHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUFDQSxpQkFBQTtFQUNBLHlCQUFBOztBRDFHQSxPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQXFSSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0FBQ1gsRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSx3QkFBQTs7QUFJUjtBQUNBO0VBaFRJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQWtIQSxxQkFBQTtFQUNBLGlCQUFBO0VBQ0EsbUJBQUE7RUFDQSxpQkFBQTtFQUNBLHlCQUFBOztBRHJIQSxPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQStTSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0FBQ1gsRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSxpQkFBQTs7QUFJUjtBRGNBO0FDQUE7RUF6WEkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBdUhBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQW1QQSx3QkFBQTtFQUNBLDJCQUFBOztBRDNXQSxlQUFFO0FBQ0YsZUFBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGdCQWZOO0FBZUYsT0FBUSxnQkFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsZ0JEZk47QUNlRixPQUFRLGdCRGROO0VDZUUsNkJBQUE7O0FEWEosZUFBRTtBQUNGLGVBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsZ0JBNUJOO0FBNEJGLE9BQVEsZ0JBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsZ0JENUJOO0FDNEJGLE9BQVEsZ0JEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixlQUFFO0FBQ0YsZUFBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGdCQ2ZOO0FEZUYsT0FBUSxnQkNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FBWEosZUFBRTtBQUNGLGVBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsZ0JDNUJOO0FENEJGLE9BQVEsZ0JDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsZ0JBNUJOO0FBNEJGLE9BQVEsZ0JBM0JOO0VBNEJFLDhCQUFBOztBRGxDSixlQUFFO0FBQ0YsZUFBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGdCQWZOO0FBZUYsT0FBUSxnQkFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsZ0JEZk47QUNlRixPQUFRLGdCRGROO0VDZUUsNkJBQUE7O0FEWEosZUFBRTtBQUNGLGVBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsZ0JBNUJOO0FBNEJGLE9BQVEsZ0JBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsZ0JENUJOO0FDNEJGLE9BQVEsZ0JEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixlQUFFO0FBQ0YsZUFBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGdCQ2ZOO0FEZUYsT0FBUSxnQkNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FBWEosZUFBRTtBQUNGLGVBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsZ0JDNUJOO0FENEJGLE9BQVEsZ0JDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsZ0JBNUJOO0FBNEJGLE9BQVEsZ0JBM0JOO0VBNEJFLDhCQUFBOztBSERSLHFCQUgwQztFQUcxQztFRW9WQTtFQ0FBO0lBTlEsd0JBQUE7SUFDQSxrQkFBQTs7O0FGL1VSLHFCQUgwQztFQUcxQztFQ29WQTtFQ0FBO0lBTlEsd0JBQUE7SUFDQSxrQkFBQTs7O0FBU1I7QURZQTtBQ0FBO0VBellJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQWlZQSwyQkFBQTtFQUNBLGNBQUE7RUFDQSxpQkFBQTs7QURqWUEsYUFBRTtBQUNGLGFBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxjQWZOO0FBZUYsT0FBUSxjQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxjRGZOO0FDZUYsT0FBUSxjRGROO0VDZUUsNkJBQUE7O0FEWEosYUFBRTtBQUNGLGFBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsY0E1Qk47QUE0QkYsT0FBUSxjQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLGNENUJOO0FDNEJGLE9BQVEsY0QzQk47RUM0QkUsOEJBQUE7O0FBbENKLGFBQUU7QUFDRixhQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsY0NmTjtBRGVGLE9BQVEsY0NkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsY0FmTjtBQWVGLE9BQVEsY0FkTjtFQWVFLDZCQUFBOztBQVhKLGFBQUU7QUFDRixhQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGNDNUJOO0FENEJGLE9BQVEsY0MzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxjQTVCTjtBQTRCRixPQUFRLGNBM0JOO0VBNEJFLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErWFI7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDSSxhQUFBO0VBQ0EsdUJBQUE7O0FBR0osQ0FBRTtBQUNGLENBQUU7RUFDRSxxQkFBQTs7QUFHSixJQUFJLEtBQU07RUFDTixvQkFBQTs7QUFJSixPQUFRLElBQUk7RUFDUixnQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBOEJKO0VBQ0ksZUFBQTtFQUNBLG9CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBO0VBQ0EscUJBQUE7O0FBRUEsQ0FBQztBQUNELENBQUM7RUFDRyxxQkFBQTtFQUNBLGNBQUE7O0FBR0osQ0FBQztBQUNELENBQUM7RUFDRyxtQkFBQTtFQUNBLHFCQUFBO0VBQ0EsY0FBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0Esb0JBQUE7O0FBR0osQ0FBQztBQUNELENBQUM7RUFDRyxtQkFBQTtFQUNBLHFCQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBc0VSLENBS0k7QUFKSixFQUlJO0FBSEosRUFHSTtFQUNJLHdCQUFBOztBQUlSLEdBQUk7RUFFQSxzQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTRCSjtFQUdJLGlCQUFBO0VBQ0Esa0JBQUE7O0FBSUo7RUFDSSxzQkFBQTs7QUFESixFQUdJO0VBQ0ksc0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF5Q1I7RUExcEJJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURFQSxLQUFFO0FBQ0YsS0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLE1EZk47QUNlRixPQUFRLE1EZE47RUNlRSw2QkFBQTs7QURYSixLQUFFO0FBQ0YsS0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsTUQ1Qk47QUM0QkYsT0FBUSxNRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osS0FBRTtBQUNGLEtBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQ2ZOO0FEZUYsT0FBUSxNQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxNQWZOO0FBZUYsT0FBUSxNQWROO0VBZUUsNkJBQUE7O0FBWEosS0FBRTtBQUNGLEtBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUM1Qk47QUQ0QkYsT0FBUSxNQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FBd25CUjtBQUNBO0VBQ0ksZ0JBQUE7O0FBRUEsS0FBTTtBQUFOLEtBQU07RUFDRixjQUFBO0VBQ0EsbUJBQUE7RUFsb0JKLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQXVHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUFDQSxpQkFBQTtFQUNBLHlCQUFBOztBRDFHQSxPQUFRLE1DNm5CRjtBRDduQk4sT0FBUSxNQzZuQkY7RUQ1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FEREosT0FBUSxNQzZuQkY7QUQ3bkJOLE9BQVEsTUM2bkJGO0VENW5CRiw4QkFBQTs7QUNESixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBRHFSSixDQUFFLFFDdVdJO0FEdldOLENBQUUsUUN1V0k7QUR0V04sRUFBRyxRQ3NXRztBRHRXTixFQUFHLFFDc1dHO0FEcldOLEVBQUcsUUNxV0c7QURyV04sRUFBRyxRQ3FXRztBRHBXTixFQUFHLFFDb1dHO0FEcFdOLEVBQUcsUUNvV0c7QURuV04sTUFBTyxRQ21XRDtBRG5XTixNQUFPLFFDbVdEO0FEbFdOLEdBQUksUUNrV0U7QURsV04sR0FBSSxRQ2tXRTtBRGpXTixLQUFNLFFDaVdBO0FEaldOLEtBQU0sUUNpV0E7QURoV04sVUFBVyxRQ2dXTDtBRGhXTixVQUFXLFFDZ1dMO0FEL1ZOLEVBQUcsUUMrVkc7QUQvVk4sRUFBRyxRQytWRztBRDlWTixHQUFJLFFDOFZFO0FEOVZOLEdBQUksUUM4VkU7QUQ3Vk4sRUFBRyxRQzZWRztBRDdWTixFQUFHLFFDNlZHO0FENVZOLEdBQUksUUM0VkU7QUQ1Vk4sR0FBSSxRQzRWRTtBRDNWTixFQUFHLFFDMlZHO0FEM1ZOLEVBQUcsUUMyVkc7QUQxVk4sR0FBSSxRQzBWRTtBRDFWTixHQUFJLFFDMFZFO0FEelZOLEVBQUcsUUN5Vkc7QUR6Vk4sRUFBRyxRQ3lWRztBRHhWTixHQUFJLFFDd1ZFO0FEeFZOLEdBQUksUUN3VkU7QUR2Vk4sRUFBRyxRQ3VWRztBRHZWTixFQUFHLFFDdVZHO0FEdFZOLEdBQUksUUNzVkU7QUR0Vk4sR0FBSSxRQ3NWRTtFRHJWRix3QkFBQTs7QUF4U0osT0FBUSxNQzZuQkY7QUQ3bkJOLE9BQVEsTUM2bkJGO0VENW5CRiw4QkFBQTs7QUNESixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBRERKLE9BQVEsTUM2bkJGO0FEN25CTixPQUFRLE1DNm5CRjtFRDVuQkYsOEJBQUE7O0FDREosT0FBUSxNQTZuQkY7QUE3bkJOLE9BQVEsTUE2bkJGO0VBNW5CRiw4QkFBQTs7QUFxUkosQ0FBRSxRQXVXSTtBQXZXTixDQUFFLFFBdVdJO0FBdFdOLEVBQUcsUUFzV0c7QUF0V04sRUFBRyxRQXNXRztBQXJXTixFQUFHLFFBcVdHO0FBcldOLEVBQUcsUUFxV0c7QUFwV04sRUFBRyxRQW9XRztBQXBXTixFQUFHLFFBb1dHO0FBbldOLE1BQU8sUUFtV0Q7QUFuV04sTUFBTyxRQW1XRDtBQWxXTixHQUFJLFFBa1dFO0FBbFdOLEdBQUksUUFrV0U7QUFqV04sS0FBTSxRQWlXQTtBQWpXTixLQUFNLFFBaVdBO0FBaFdOLFVBQVcsUUFnV0w7QUFoV04sVUFBVyxRQWdXTDtBQS9WTixFQUFHLFFBK1ZHO0FBL1ZOLEVBQUcsUUErVkc7QUE5Vk4sR0FBSSxRQThWRTtBQTlWTixHQUFJLFFBOFZFO0FBN1ZOLEVBQUcsUUE2Vkc7QUE3Vk4sRUFBRyxRQTZWRztBQTVWTixHQUFJLFFBNFZFO0FBNVZOLEdBQUksUUE0VkU7QUEzVk4sRUFBRyxRQTJWRztBQTNWTixFQUFHLFFBMlZHO0FBMVZOLEdBQUksUUEwVkU7QUExVk4sR0FBSSxRQTBWRTtBQXpWTixFQUFHLFFBeVZHO0FBelZOLEVBQUcsUUF5Vkc7QUF4Vk4sR0FBSSxRQXdWRTtBQXhWTixHQUFJLFFBd1ZFO0FBdlZOLEVBQUcsUUF1Vkc7QUF2Vk4sRUFBRyxRQXVWRztBQXRWTixHQUFJLFFBc1ZFO0FBdFZOLEdBQUksUUFzVkU7RUFyVkYsd0JBQUE7O0FBNFZSO0FBQ0EsS0FBTTtFQUNGLGdDQUFBOztBQUdKO0VBNW9CSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUE0b0JBLGdCQUFBOztBRDNvQkEsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7RUFDSiw4QkFBQTs7QUE2b0JSLEtBQU07RUFuckJGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURFQSxLQytxQkUsR0QvcUJBO0FBQ0YsS0M4cUJFLEdEOXFCQTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZ3FCTixHRC9xQkE7QUFlRixPQUFRLE1DZ3FCTixHRDlxQkE7RUFlRSw2QkFBQTs7QUNESixPQUFRLE1BZ3FCTixHRC9xQkE7QUNlRixPQUFRLE1BZ3FCTixHRDlxQkE7RUNlRSw2QkFBQTs7QURYSixLQzBxQkUsR0QxcUJBO0FBQ0YsS0N5cUJFLEdEenFCQTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzhvQk4sR0QxcUJBO0FBNEJGLE9BQVEsTUM4b0JOLEdEenFCQTtFQTRCRSw4QkFBQTs7QUNESixPQUFRLE1BOG9CTixHRDFxQkE7QUM0QkYsT0FBUSxNQThvQk4sR0R6cUJBO0VDNEJFLDhCQUFBOztBQWxDSixLQStxQkUsR0EvcUJBO0FBQ0YsS0E4cUJFLEdBOXFCQTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZ3FCTixHQS9xQkE7QURlRixPQUFRLE1DZ3FCTixHQTlxQkE7RURlRSw2QkFBQTs7QUNESixPQUFRLE1BZ3FCTixHQS9xQkE7QUFlRixPQUFRLE1BZ3FCTixHQTlxQkE7RUFlRSw2QkFBQTs7QUFYSixLQTBxQkUsR0ExcUJBO0FBQ0YsS0F5cUJFLEdBenFCQTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzhvQk4sR0ExcUJBO0FENEJGLE9BQVEsTUM4b0JOLEdBenFCQTtFRDRCRSw4QkFBQTs7QUNESixPQUFRLE1BOG9CTixHQTFxQkE7QUE0QkYsT0FBUSxNQThvQk4sR0F6cUJBO0VBNEJFLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEycUJSO0VBQ0ksc0JBQUE7RUFDQSxxQkFBQTs7QUhyckJKLHFCQUgwQztFQUcxQztJR3dyQlEscUJBQUE7SUFDQSxvQkFBQTs7O0FGenJCUixxQkFIMEM7RUFHMUM7SUV3ckJRLHFCQUFBO0lBQ0Esb0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE0QlI7RUFDSSxjQUFBO0VBRUEsdUJBQUE7RUF0dkJBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURFQSxLQUFFO0FBQ0YsS0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLE1EZk47QUNlRixPQUFRLE1EZE47RUNlRSw2QkFBQTs7QURYSixLQUFFO0FBQ0YsS0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsTUQ1Qk47QUM0QkYsT0FBUSxNRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osS0FBRTtBQUNGLEtBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQ2ZOO0FEZUYsT0FBUSxNQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxNQWZOO0FBZUYsT0FBUSxNQWROO0VBZUUsNkJBQUE7O0FBWEosS0FBRTtBQUNGLEtBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUM1Qk47QUQ0QkYsT0FBUSxNQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FBNnNCUixLQU1JLE1BQUs7QUFOVCxLQU9JLE1BQUs7RUFDRCxxQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXVFUixLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTDtBQUNBLE1BQU07RUFHRixxQkFBQTtFQUNBLFNBQUE7RUFDQSxnQkFBQTtFQUNBLDhCQUFBO0VBQ0EsY0FBQTtFQUNBLG1CQUFBO0VBQ0EseUJBQUE7RUFDQSxnQkFBQTtFQUNBLG1CQUFBO0VBQ0Esd0JBQUE7RUFDQSw4Q0FBQTs7QUFLSjtFQUNJLHdCQUFBOztBQUtKLEtBQUssYUFBYTtBQUNsQixLQUFLLGFBQWE7QUFDbEIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtBQUNwQixLQUFLLGNBQWM7QUFDbkIsS0FBSyxjQUFjO0FBQ25CLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0FBQ3BCLFFBQVE7QUFDUixRQUFRO0FBQ1IsTUFBTSxVQUFVO0FBQ2hCLE1BQU0sVUFBVTtFQUNaLHlCQUFBO0VBQ0EsMEJBQUE7RUFDQSxpQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0csT0NoMEI2QixrQkRnMEI3Qjs7QUFFSDtFQUNHLE9DbjBCNkIsa0JEbTBCN0I7O0FBRUg7RUFDRyxPQ3QwQjZCLGtCRHMwQjdCOzs7Ozs7Ozs7Ozs7OztBQWlCSDtFQUNJLGVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzQko7RUFDSSxjQUFBO0VBQ0EsZUFBQTs7QUFGSixNQUlJO0VBRUksc0JBQUE7O0FBSVIsaUJBQWtCO0VBQ2QseUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRW41Qko7RUFDRSxhQUFhLGVBQWI7RUFDQSxTQUFTLHdCQUFUO0VBQ0EsU0FBUyxnQ0FBdUMsT0FBTywwQkFDakQsMEJBQWlDLE9BQU8sYUFDeEMseUJBQWdDLE9BQU8saUJBQ3ZDLHlCQUFnQyxPQUFPLE1BSDdDO0VBSUEsbUJBQUE7RUFDQSxrQkFBQTs7QUFnQkY7QUFDQSxDQUFDO0VBQ0MsYUFBYSxlQUFiO0VBQ0EscUJBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsY0FBQTtFQUNBLG1DQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9RRixDQUFDLE9BQWlCO0VBQ2hCLHVCQUFBO0VBQ0EsbUJBQUE7RUFDQSxvQkFBQTs7QUFHRixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7QUFDekIsQ0FBQyxPQUFpQjtFQUFPLGNBQUE7O0FBQ3pCLENBQUMsT0FBaUI7RUFBTyxjQUFBOztBQUN6QixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE2RHpCLENBQUMsT0FBaUI7RUFDaEIseUJBQUE7RUFDQSw0QkFBQTtFQUNBLG1CQUFBOztBQUdGLENBQUMsT0FBaUI7RUF6Q2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsYUFBbkI7RUFDSSxlQUFlLGFBQWY7RUFDSSxXQUFXLGFBQVg7O0FBdUNWLENBQUMsT0FBaUI7RUExQ2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsY0FBbkI7RUFDSSxlQUFlLGNBQWY7RUFDSSxXQUFXLGNBQVg7O0FBd0NWLENBQUMsT0FBaUI7RUEzQ2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsY0FBbkI7RUFDSSxlQUFlLGNBQWY7RUFDSSxXQUFXLGNBQVg7O0FBMENWLENBQUMsT0FBaUI7RUF0Q2hCLFFBQVEsa0VBQVI7RUFDQSxtQkFBbUIsWUFBbkI7RUFDSSxlQUFlLFlBQWY7RUFDSSxXQUFXLFlBQVg7O0FBb0NWLENBQUMsT0FBaUI7RUF2Q2hCLFFBQVEsa0VBQVI7RUFDQSxtQkFBbUIsWUFBbkI7RUFDSSxlQUFlLFlBQWY7RUFDSSxXQUFXLFlBQVg7O0FBc0NWLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7QUFDeEIsS0FBTSxFQUFDLE9BQWlCO0FBQ3hCLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7RUFDdEIsWUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNCRixDQUFDLE9BQWlCO0VBQ2hCLDZDQUFBO0VBQ1EscUNBQUE7O0FBR1YsQ0FBQyxPQUFpQjtFQUNoQix1Q0FBdUMsUUFBdkM7RUFDUSwrQkFBK0IsUUFBL0I7O0FBR1Y7RUFDRTtJQUNFLG1CQUFtQixZQUFuQjtJQUNRLFdBQVcsWUFBWDs7RUFFVjtJQUNFLG1CQUFtQixjQUFuQjtJQUNRLFdBQVcsY0FBWDs7O0FBSVo7RUFDRTtJQUNFLG1CQUFtQixZQUFuQjtJQUNRLFdBQVcsWUFBWDs7RUFFVjtJQUNFLG1CQUFtQixjQUFuQjtJQUNRLFdBQVcsY0FBWDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBOENSLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbGZkLDZFQUFBOztBQXdmQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZmZCw2RUFBQTs7QUE2ZkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1ZmQsNkVBQUE7O0FBa2dCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpnQmQsNkVBQUE7O0FBdWdCQSxDQURILE9BQWlCLEdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRnQmQsNkVBQUE7O0FBNGdCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNnQmQsNkVBQUE7O0FBaWhCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhoQmQsNkVBQUE7O0FBc2hCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJoQmQsNkVBQUE7O0FBMmhCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFoQmQsNkVBQUE7O0FBZ2lCQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvaEJkLDZFQUFBOztBQXFpQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwaUJkLDZFQUFBOztBQTBpQkEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBemlCZCw2RUFBQTs7QUEraUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOWlCZCw2RUFBQTs7QUFvakJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbmpCZCw2RUFBQTs7QUF5akJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeGpCZCw2RUFBQTs7QUE4akJBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdqQmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF3bUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdm1CZCw2RUFBQTs7QUE2bUJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNW1CZCw2RUFBQTs7QUFrbkJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBam5CZCw2RUFBQTs7QUF1bkJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdG5CZCw2RUFBQTs7QUE0bkJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM25CZCw2RUFBQTs7QUFpb0JBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaG9CZCw2RUFBQTs7QUFzb0JBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcm9CZCw2RUFBQTs7QUEyb0JBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMW9CZCw2RUFBQTs7QUFncEJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL29CZCw2RUFBQTs7QUFxcEJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHBCZCw2RUFBQTs7QUEwcEJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenBCZCw2RUFBQTs7QUErcEJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXBCZCw2RUFBQTs7QUFvcUJBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnFCZCw2RUFBQTs7QUF5cUJBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHFCZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW10QkEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsdEJkLDZFQUFBOztBQXd0QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2dEJkLDZFQUFBOztBQTZ0QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1dEJkLDZFQUFBOztBQWt1QkEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBanVCZCw2RUFBQTs7QUF1dUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHVCZCw2RUFBQTs7QUE0dUJBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTN1QmQsNkVBQUE7O0FBaXZCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh2QmQsNkVBQUE7O0FBc3ZCQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ2QmQsNkVBQUE7O0FBMnZCQSxDQURILE9BQWlCLFFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF2QmQsNkVBQUE7O0FBZ3dCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS92QmQsNkVBQUE7O0FBcXdCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB3QmQsNkVBQUE7O0FBMHdCQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp3QmQsNkVBQUE7O0FBK3dCQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl3QmQsNkVBQUE7O0FBb3hCQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFueEJkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEwekJBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenpCZCw2RUFBQTs7QUErekJBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXpCZCw2RUFBQTs7QUFvMEJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbjBCZCw2RUFBQTs7QUF5MEJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeDBCZCw2RUFBQTs7QUE4MEJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNzBCZCw2RUFBQTs7QUFtMUJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbDFCZCw2RUFBQTs7QUF3MUJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdjFCZCw2RUFBQTs7QUE2MUJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNTFCZCw2RUFBQTs7QUFrMkJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBajJCZCw2RUFBQTs7QUF1MkJBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXQyQmQsNkVBQUE7O0FBNDJCQSxDQURILE9BQWlCLElBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTMyQmQsNkVBQUE7O0FBaTNCQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWgzQmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQSs2QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5NkJkLDZFQUFBOztBQW83QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuN0JkLDZFQUFBOztBQXk3QkEsQ0FESCxPQUFpQixJQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4N0JkLDZFQUFBOztBQTg3QkEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3N0JkLDZFQUFBOztBQW04QkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsOEJkLDZFQUFBOztBQXc4QkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2OEJkLDZFQUFBOztBQTY4QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1OEJkLDZFQUFBOztBQWs5QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqOUJkLDZFQUFBOztBQXU5QkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0OUJkLDZFQUFBOztBQTQ5QkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzOUJkLDZFQUFBOztBQWkrQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoK0JkLDZFQUFBOztBQXMrQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyK0JkLDZFQUFBOztBQTIrQkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExK0JkLDZFQUFBOztBQWcvQkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvK0JkLDZFQUFBOztBQXEvQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwL0JkLDZFQUFBOztBQTAvQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6L0JkLDZFQUFBOztBQSsvQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5L0JkLDZFQUFBOztBQW9nQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuZ0NkLDZFQUFBOztBQXlnQ0EsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4Z0NkLDZFQUFBOztBQThnQ0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3Z0NkLDZFQUFBOztBQW1oQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsaENkLDZFQUFBOztBQXdoQ0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdmhDZCw2RUFBQTs7QUE2aENBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNWhDZCw2RUFBQTs7QUFraUNBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBamlDZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFnb0NBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL25DZCw2RUFBQTs7QUFxb0NBLENBREgsT0FBaUIsbUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBvQ2QsNkVBQUE7O0FBMG9DQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXpvQ2QsNkVBQUE7O0FBK29DQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5b0NkLDZFQUFBOztBQW9wQ0EsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFucENkLDZFQUFBOztBQXlwQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4cENkLDZFQUFBOztBQThwQ0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3cENkLDZFQUFBOztBQW1xQ0EsQ0FESCxPQUFpQixxQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHFDZCw2RUFBQTs7QUF3cUNBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdnFDZCw2RUFBQTs7QUE2cUNBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXFDZCw2RUFBQTs7QUFrckNBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpyQ2QsNkVBQUE7O0FBdXJDQSxDQURILE9BQWlCLHNCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0ckNkLDZFQUFBOztBQTRyQ0EsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzckNkLDZFQUFBOztBQWlzQ0EsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHNDZCw2RUFBQTs7QUFzc0NBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnNDZCw2RUFBQTs7QUEyc0NBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXNDZCw2RUFBQTs7QUFndENBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3NDZCw2RUFBQTs7QUFxdENBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB0Q2QsNkVBQUE7O0FBMHRDQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp0Q2QsNkVBQUE7O0FBK3RDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl0Q2QsNkVBQUE7O0FBb3VDQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW51Q2QsNkVBQUE7O0FBeXVDQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4dUNkLDZFQUFBOztBQTh1Q0EsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3VDZCw2RUFBQTs7QUFtdkNBLENBREgsT0FBaUIsMEJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWx2Q2QsNkVBQUE7O0FBd3ZDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZ2Q2QsNkVBQUE7O0FBNnZDQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1dkNkLDZFQUFBOztBQWt3Q0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqd0NkLDZFQUFBOztBQXV3Q0EsQ0FESCxPQUFpQixxQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHdDZCw2RUFBQTs7QUE0d0NBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3dDZCw2RUFBQTs7QUFpeENBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh4Q2QsNkVBQUE7O0FBc3hDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ4Q2QsNkVBQUE7O0FBMnhDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF4Q2QsNkVBQUE7O0FBZ3lDQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEveENkLDZFQUFBOztBQXF5Q0EsQ0FESCxPQUFpQixzQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHlDZCw2RUFBQTs7QUEweUNBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenlDZCw2RUFBQTs7QUEreUNBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl5Q2QsNkVBQUE7O0FBb3pDQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW56Q2QsNkVBQUE7O0FBeXpDQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4ekNkLDZFQUFBOztBQTh6Q0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3ekNkLDZFQUFBOztBQW0wQ0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbDBDZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBaStDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWgrQ2QsNkVBQUE7O0FBcytDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXIrQ2QsNkVBQUE7O0FBMitDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTErQ2QsNkVBQUE7O0FBZy9DQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS8rQ2QsNkVBQUE7O0FBcS9DQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXAvQ2QsNkVBQUE7O0FBMC9DQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXovQ2QsNkVBQUE7O0FBKy9DQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTkvQ2QsNkVBQUE7O0FBb2dEQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5nRGQsNkVBQUE7O0FBeWdEQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhnRGQsNkVBQUE7O0FBOGdEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdnRGQsNkVBQUE7O0FBbWhEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxoRGQsNkVBQUE7O0FBd2hEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2aERkLDZFQUFBOztBQTZoREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1aERkLDZFQUFBOztBQWtpREEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBamlEZCw2RUFBQTs7QUF1aURBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdGlEZCw2RUFBQTs7QUE0aURBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNpRGQsNkVBQUE7O0FBaWpEQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhqRGQsNkVBQUE7O0FBc2pEQSxDQURILE9BQWlCLG1CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyakRkLDZFQUFBOztBQTJqREEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExakRkLDZFQUFBOztBQWdrREEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL2pEZCw2RUFBQTs7QUFxa0RBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcGtEZCw2RUFBQTs7QUEwa0RBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBemtEZCw2RUFBQTs7QUEra0RBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOWtEZCw2RUFBQTs7QUFvbERBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5sRGQsNkVBQUE7O0FBeWxEQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhsRGQsNkVBQUE7O0FBOGxEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdsRGQsNkVBQUE7O0FBbW1EQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxtRGQsNkVBQUE7O0FBd21EQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2bURkLDZFQUFBOztBQTZtREEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1bURkLDZFQUFBOztBQWtuREEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqbkRkLDZFQUFBOztBQXVuREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0bkRkLDZFQUFBOztBQTRuREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzbkRkLDZFQUFBOztBQWlvREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFob0RkLDZFQUFBOztBQXNvREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyb0RkLDZFQUFBOztBQTJvREEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExb0RkLDZFQUFBOztBQWdwREEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvb0RkLDZFQUFBOztBQXFwREEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwcERkLDZFQUFBOztBQTBwREEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6cERkLDZFQUFBOztBQStwREEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5cERkLDZFQUFBOztBQW9xREEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFucURkLDZFQUFBOztBQXlxREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4cURkLDZFQUFBOztBQThxREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3cURkLDZFQUFBOztBQW1yREEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsckRkLDZFQUFBOztBQXdyREEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2ckRkLDZFQUFBOztBQTZyREEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXJEZCw2RUFBQTs7QUFrc0RBLENBREgsT0FBaUIsd0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpzRGQsNkVBQUE7O0FBdXNEQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRzRGQsNkVBQUE7O0FBNHNEQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzc0RkLDZFQUFBOztBQWl0REEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFodERkLDZFQUFBOztBQXN0REEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnREZCw2RUFBQTs7QUEydERBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXREZCw2RUFBQTs7QUFndURBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3REZCw2RUFBQTs7QUFxdURBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHVEZCw2RUFBQTs7QUEwdURBLENBREgsT0FBaUIsbUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp1RGQsNkVBQUE7O0FBK3VEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl1RGQsNkVBQUE7O0FBb3ZEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFudkRkLDZFQUFBOztBQXl2REEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4dkRkLDZFQUFBOztBQTh2REEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3ZEZCw2RUFBQTs7QUFtd0RBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHdEZCw2RUFBQTs7QUF3d0RBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZ3RGQsNkVBQUE7O0FBNndEQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTV3RGQsNkVBQUE7O0FBa3hEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWp4RGQsNkVBQUE7O0FBdXhEQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXR4RGQsNkVBQUE7O0FBNHhEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTN4RGQsNkVBQUE7O0FBaXlEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh5RGQsNkVBQUE7O0FBc3lEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyeURkLDZFQUFBOztBQTJ5REEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExeURkLDZFQUFBOztBQWd6REEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3lEZCw2RUFBQTs7QUFxekRBLENBREgsT0FBaUIsUUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHpEZCw2RUFBQTs7QUEwekRBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenpEZCw2RUFBQTs7QUErekRBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXpEZCw2RUFBQTs7QUFvMERBLENBREgsT0FBaUIscUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW4wRGQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQ3NFSjtFQUVJLHFCQUFBO0VBQ0Esc0JBQUE7RUFDQSxzQkFBQTtFQUdBLFNBQUE7RUFDQSxxQkFBQTtFQUNBLFNBQUE7RUFFQSxzQkFBQTtFSDlEQSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsZ0JBQUE7RUcrREEsY0FBQTtFQUNBLG1CQUFBO0VBQ0EscUJBQUE7RUFFQSxlQUFBO0VBQ0EsaUNBQUE7RUFDQSx3QkFBQTs7QUpwRUEsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7RUFDSiw4QkFBQTs7QUdxRUo7QUFDQSxJQUFDO0FBQ0QsSUFBQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTs7QUFHSixJQUFDO0FBQ0QsSUFBQztFQUNHLHlCQUFBOztBQUdKLElBQUM7QUFDRCxJQUFDO0VBQ0cseUJBQUE7RUFDQSwyQkFBQTtFQUdBLG1CQUFBOztBQUdKLElBQUM7QUFDRCxJQUFDO0VBQ0cseUJBQUE7O0FBR0osTUFBTSxJQUFDO0FBQ1AsS0FBSyxJQUFDO0VBR0YsU0FBQTs7QUFHSixJQUFFO0VBQ0Usb0JBQUE7O0FBSVI7RUFLUSxxQ0FBQTs7QUFMUixPQVNJLE9BQU07QUFUVixPQVVJLE1BQUs7RUFDRCxpQkFBQTtFQUNBLGtCQUFBO0VBQ0EscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBdUNKO0FBQ0EsZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTtFQUNBLGNBQUE7O0FBR0osZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTs7QUFHSixlQUFDO0FBQ0QsZUFBQztFQUNHLHlCQUFBO0VBQ0Esc0JBQUE7O0FBR0osZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErRko7QUFDQSxhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTs7QUFHSixhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBOztBQUdKLGFBQUM7QUFDRCxhQUFDO0VBQ0cseUJBQUE7RUFDQSxzQkFBQTs7QUFHSixhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQWtDSjtBQUFBLElBRkE7QUFHQSxjQUFDO0FBQUQsSUFIQSxVQUdDO0FBQ0QsY0FBQztBQUFELElBSkEsVUFJQztBQUNELGNBQUM7QUFBRCxJQUxBLFVBS0M7QUFDRCxjQUFDO0FBQUQsSUFOQSxVQU1DO0FBQ0QsY0FBQztBQUFELElBUEEsVUFPQztBQUNELGNBQUM7QUFBRCxJQVJBLFVBUUM7QUFDRCxjQUFDO0FBQUQsSUFUQSxVQVNDO0FBQ0QsY0FBQztBQUFELElBVkEsVUFVQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTtFQUNBLGVBQUE7RUFDQSxtQkFBQTs7QUFHSixjQUFDO0FBQUQsSUFqQkEsVUFpQkM7QUFDRCxjQUFDO0FBQUQsSUFsQkEsVUFrQkM7RUFDRyxzQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFrQ1I7RUFFSSxrQ0FBQTtFQUdBLGtCQUFBOztBQUVBLFdBQUU7RUFDRSx5QkFBQTs7QUFLUixPQUlJLE9BQU07QUFKVixPQUtJLE1BQUs7RUFDRCx5QkFBQTtFQUNBLDRCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvSFI7RUFDSSx3QkFBQTtFQUNBLCtCQUFBO0VBQ0EsZ0RBQUE7RUFDQSxzQkFBQTs7QUFFQSxlQUFnQjtFQUNaLDJCQUFBO0VBQ0EsNENBQUE7O0FBRUosYUFBYztFQUNWLDJCQUFBO0VBQ0EsNENBQUE7O0FBRUosY0FBZTtBQUNmLElBQUksVUFBVztFQUNYLDJCQUFBO0VBQ0EsNENBQUE7O0FBSVI7RUFDSSx3QkFBQTtFQUNBLGVBQUE7RUFDQSw4QkFBQTtFQUNBLCtDQUFBO0VBQ0Esc0JBQUE7O0FBRUEsZUFBZ0I7RUFDWiwwQkFBQTtFQUNBLDJDQUFBOztBQUVKLGFBQWM7RUFDViwwQkFBQTtFQUNBLDJDQUFBOztBQUVKLGNBQWU7QUFDZixJQUFJLFVBQVc7RUFDWCwwQkFBQTtFQUNBLDJDQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEyQ1I7RUFVUSxnQkFBQTs7QUFOSixhQUFDO0VBQ0csMEJBQUE7RUFDQSw2QkFBQTs7QUFPSixhQUFDO0VBQ0cseUJBQUE7RUFDQSw0QkFBQTs7QUFLSixhQUFDLE1BQU87QUFDUixhQUFDLE1BQU8sZ0JBQUc7QUFDWDtBQUNBLGFBQUU7QUFDRixhQUFDO0FBQ0QsYUFBRSxnQkFBRztFQUNELHNCQUFBOztBQUdKLGFBQUMsTUFBTSxXQUFZLGdCQUFHO0FBQ3RCLGFBQUMsTUFBTSxXQUFZLGdCQUFHLEtBQUs7QUFDM0IsYUFBQztBQUNELGFBQUMsS0FBSztBQUNOLGFBQUMsV0FBWSxnQkFBRztBQUNoQixhQUFDLFdBQVksZ0JBQUcsS0FBSztFQUNqQiwwQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBd0ZKO0FBQ0EscUJBQUM7QUFDRCxxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDO0FBQ0QscUJBQUM7QUFDRCxxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDO0VBQ0cseUJBQUE7O0FBR0oscUJBQUMsZUFBZTtBQUNoQixxQkFBQyxlQUFlO0FBQ2hCLHFCQUFDLGVBQWU7RUFDWix5QkFBQTs7QUFHSixxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDLGFBQWE7QUFDZCxxQkFBQyxhQUFhO0FBQ2QscUJBQUMsYUFBYTtFQUNWLHlCQUFBOztBQUdKLHFCQUFDO0FBQ0QscUJBQUMsY0FBYztBQUNmLHFCQUFDLGNBQWM7QUFDZixxQkFBQyxjQUFjO0FBQ2YscUJBQUM7QUFDRCxxQkFBQyxVQUFVO0FBQ1gscUJBQUMsVUFBVTtBQUNYLHFCQUFDLFVBQVU7RUFDUCx5QkFBQTs7QUFHSixxQkFBQztFQUNHLDBCQUFBO0VBQ0EsMkJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBcUNSO0VBRUksVUFBQTtFQUNBLGlDQUFBO0VBQ0EsZ0JBQUE7RUFHQSxlQUFBOztBQUVBO0FBQ0EsVUFBQztBQUNELFVBQUM7RUFDRyw0QkFBQTtFQUNBLDZCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQUFDO0FBQ0QsVUFBQztFQUNHLGdDQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBQUM7QUFDRCxVQUFDO0VBQ0csMEJBQUE7RUFDQSw2QkFBQTtFQUNBLDRCQUFBOztBQUdKLFVBQUM7QUFDRCxVQUFDO0VBQ0csZ0NBQUE7RUFDQSw2QkFBQTtFQUNBLGNBQUE7O0FBS1IsT0FFSSxPQUFNO0FBRlYsT0FHSSxNQUFLO0VBQ0QsVUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1Q0osVUFGTTtBQUdOLFVBSE0sZUFHTDtBQUNELFVBSk0sZUFJTDtFQUNHLDRCQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBVk0sZUFVTDtBQUNELFVBWE0sZUFXTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQWhCTSxlQWdCTDtBQUNELFVBakJNLGVBaUJMO0VBQ0csc0JBQUE7O0FBR0osVUFyQk0sZUFxQkw7QUFDRCxVQXRCTSxlQXNCTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1Q0osVUFGTTtBQUdOLFVBSE0sYUFHTDtBQUNELFVBSk0sYUFJTDtFQUNHLDRCQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBVk0sYUFVTDtBQUNELFVBWE0sYUFXTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQWhCTSxhQWdCTDtBQUNELFVBakJNLGFBaUJMO0VBQ0csc0JBQUE7O0FBR0osVUFyQk0sYUFxQkw7QUFDRCxVQXRCTSxhQXNCTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUM5OEJSO0VKV0kscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7RUl0SEEsMkJBQUE7O0FMWUEsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtFQUNKLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7QUlNSixhQUFDO0FBQ0QsYUFBQztBQUNELGFBQUM7QUFDRCxhQUFDO0FBQ0QsYUFBQztBQUNELGFBQUM7RUFDRyxxQkFBQTtFQUNBLGtCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQWtESixLQVJDLGFBUUE7QUFBRCxLQVBDLGVBT0E7QUFBRCxLQU5DLGNBTUE7QUFBRCxLQUxDLFlBS0E7QUFBRCxLQUpDLFlBSUE7QUFBRCxLQUhDLGVBR0E7QUFBRCxNQUZFLFVBRUQ7QUFBRCxRQUFDO0VBQ0cseUJBQUE7RUFDQSwwQkFBQTs7QUFFSixLQVpDLGFBWUE7QUFBRCxLQVhDLGVBV0E7QUFBRCxLQVZDLGNBVUE7QUFBRCxLQVRDLFlBU0E7QUFBRCxLQVJDLFlBUUE7QUFBRCxLQVBDLGVBT0E7QUFBRCxNQU5FLFVBTUQ7QUFBRCxRQUFDO0VBQ0cseUJBQUE7RUFDQSwwQkFBQTs7QUFFSixLQWhCQyxhQWdCQTtBQUFELEtBZkMsZUFlQTtBQUFELEtBZEMsY0FjQTtBQUFELEtBYkMsWUFhQTtBQUFELEtBWkMsWUFZQTtBQUFELEtBWEMsZUFXQTtBQUFELE1BVkUsVUFVRDtBQUFELFFBQUM7RUFDRyx5QkFBQTtFQUNBLDBCQUFBOztBQUVKLEtBcEJDLGFBb0JBO0FBQUQsS0FuQkMsZUFtQkE7QUFBRCxLQWxCQyxjQWtCQTtBQUFELEtBakJDLFlBaUJBO0FBQUQsS0FoQkMsWUFnQkE7QUFBRCxLQWZDLGVBZUE7QUFBRCxNQWRFLFVBY0Q7QUFBRCxRQUFDO0VBQ0cseUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvRFIsQ0FBQztFQUdHLGtCQUFBO0VBQ0EsVUFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBR0osTUFBTyxJQUFHO0VBQ04sY0FBQTs7QUFHSixRQUFTLElBQUc7RUFDUixjQUFBOztBQUdKLFFBQVMsSUFBRztFQUNSLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFxRkosV0FBWTtFQUNSLG1CQUFBOztBQUdKLGdCQUFpQjtFQUNiLG9CQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBUHBQSixxQkFIMEM7RUFHMUM7SVE0UUUsY0FBQTtJQUNBLGtCQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7O0FQL1FGLHFCQUgwQztFQUcxQztJTzRRRSxjQUFBO0lBQ0Esa0JBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOzs7QURXRSxlQUFDO0VBQ0csdUJBQUE7O0FQM1JSLHFCQUgwQztFQUcxQyxlTzBSSztJQ3BPSCxxQkFBQTtJQUNBLDhCQUFBO0lBQ0csMkJBQUE7SUFDSyxzQkFBQTtJQVlSLHlCQUFBO0lBQ0Esb0JBQUE7SUFHQSxxQkFBQTtJQUVBLG1CQUFBO0lBOEJFLFVBQUE7SURxTFEscUJBQUE7O0VDak5WLE9BQVEsZ0JENk1MO0lDM01ELGVBQUE7SUFHQSxlQUFBO0lBR0EsT0FBQTtJQUVBLGNBQWMsMENBQWQ7OztBUHZGSixxQkFIMEM7RUFHMUMsZU0wUks7SUNwT0gscUJBQUE7SUFDQSw4QkFBQTtJQUNHLDJCQUFBO0lBQ0ssc0JBQUE7SUFZUix5QkFBQTtJQUNBLG9CQUFBO0lBR0EscUJBQUE7SUFFQSxtQkFBQTtJQThCRSxVQUFBO0lEcUxRLHFCQUFBOztFQ2pOVixPQUFRLGdCRDZNTDtJQzNNRCxlQUFBO0lBR0EsZUFBQTtJQUdBLE9BQUE7SUFFQSxjQUFjLDBDQUFkOzs7QVJ2RkoscUJBSDBDO0VBRzFDLGVPMFJLO0lDcE9ILHFCQUFBO0lBQ0EsOEJBQUE7SUFDRywyQkFBQTtJQUNLLHNCQUFBO0lBWVIseUJBQUE7SUFDQSxvQkFBQTtJQUdBLHFCQUFBO0lBRUEsbUJBQUE7SUE4QkUsbUJBQUE7SUR5TFEscUJBQUE7O0VDck5WLE9BQVEsZ0JENk1MO0lDM01ELGVBQUE7SUFHQSxlQUFBO0lBR0EsT0FBQTtJQUVBLGNBQWMsMENBQWQ7OztBUHZGSixxQkFIMEM7RUFHMUMsZU0wUks7SUNwT0gscUJBQUE7SUFDQSw4QkFBQTtJQUNHLDJCQUFBO0lBQ0ssc0JBQUE7SUFZUix5QkFBQTtJQUNBLG9CQUFBO0lBR0EscUJBQUE7SUFFQSxtQkFBQTtJQThCRSxtQkFBQTtJRHlMUSxxQkFBQTs7RUNyTlYsT0FBUSxnQkQ2TUw7SUMzTUQsZUFBQTtJQUdBLGVBQUE7SUFHQSxPQUFBO0lBRUEsY0FBYywwQ0FBZDs7O0FEbU1BLGVBQUMsTUFXRztFQUNJLHNCQUFBO0VBQ0EsV0FBQTs7QUFJUixlQUFDO0VBQ0csdUJBQUE7O0FQNVNSLHFCQUgwQztFQUcxQyxlTzJTSztJQ3JQSCxxQkFBQTtJQUNBLDhCQUFBO0lBQ0csMkJBQUE7SUFDSyxzQkFBQTtJQVlSLHlCQUFBO0lBQ0Esb0JBQUE7SUFHQSxxQkFBQTtJQUVBLG1CQUFBO0lBOEJFLFVBQUE7O0VBNUJGLE9BQVEsZ0JEOE5MO0lDNU5ELGVBQUE7SUFHQSxlQUFBO0lBR0EsT0FBQTtJQUVBLGNBQWMsMENBQWQ7OztBUHZGSixxQkFIMEM7RUFHMUMsZU0yU0s7SUNyUEgscUJBQUE7SUFDQSw4QkFBQTtJQUNHLDJCQUFBO0lBQ0ssc0JBQUE7SUFZUix5QkFBQTtJQUNBLG9CQUFBO0lBR0EscUJBQUE7SUFFQSxtQkFBQTtJQThCRSxVQUFBOztFQTVCRixPQUFRLGdCRDhOTDtJQzVORCxlQUFBO0lBR0EsZUFBQTtJQUdBLE9BQUE7SUFFQSxjQUFjLDBDQUFkOzs7QVJ2RkoscUJBSDBDO0VBRzFDLGVPMlNLO0lDclBILHFCQUFBO0lBQ0EsOEJBQUE7SUFDRywyQkFBQTtJQUNLLHNCQUFBO0lBWVIseUJBQUE7SUFDQSxvQkFBQTtJQUdBLHFCQUFBO0lBRUEsbUJBQUE7SUE4QkUsbUJBQUE7O0VBNUJGLE9BQVEsZ0JEOE5MO0lDNU5ELGVBQUE7SUFHQSxlQUFBO0lBR0EsT0FBQTtJQUVBLGNBQWMsMENBQWQ7OztBUHZGSixxQkFIMEM7RUFHMUMsZU0yU0s7SUNyUEgscUJBQUE7SUFDQSw4QkFBQTtJQUNHLDJCQUFBO0lBQ0ssc0JBQUE7SUFZUix5QkFBQTtJQUNBLG9CQUFBO0lBR0EscUJBQUE7SUFFQSxtQkFBQTtJQThCRSxtQkFBQTs7RUE1QkYsT0FBUSxnQkQ4Tkw7SUM1TkQsZUFBQTtJQUdBLGVBQUE7SUFHQSxPQUFBO0lBRUEsY0FBYywwQ0FBZDs7O0FEb05BLGVBQUMsSUFVRztFQUNJLHNCQUFBO0VBQ0EsV0FBQTs7QUFaUixlQUFDLElBZUc7RUFDSSwwQkFBQTtFQUNBLDJCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvQ1o7RUFFSSxrQkFBQTs7QUFGSixpQkFJSSxNQUFLO0FBSlQsaUJBS0ksTUFBSztBQUxULGlCQU1JLE1BQUs7QUFOVCxpQkFPSSxNQUFLO0FBUFQsaUJBUUksTUFBSztBQVJULGlCQVNJLE1BQUs7RUFDRCxzQkFBQTtFQUNBLFdBQUE7RUFDQSx1QkFBQTs7QUFFQSxpQkFWSixNQUFLLGFBVUE7QUFBRCxpQkFUSixNQUFLLGVBU0E7QUFBRCxpQkFSSixNQUFLLGNBUUE7QUFBRCxpQkFQSixNQUFLLFlBT0E7QUFBRCxpQkFOSixNQUFLLFlBTUE7QUFBRCxpQkFMSixNQUFLLGVBS0E7RUFDRyxrQkFBQTs7QUFmWixpQkFtQkk7RVJpQ0EsaUNBQUE7RVEvQkksa0JBQUE7RUFDQSxlQUFBO0VBQ0EsTUFBQTs7O0FBRUEsaUJBTkosS0FNSztFQUNHLG1CQUFBOztBQUlKLGlCQVhKLEtBV0ssTUFBTTtFQUNILHNCQUFBIn0= */

--- a/docs/index.html
+++ b/docs/index.html
@@ -123,6 +123,9 @@
                     <pre class="docs-code"><code>.error</code></pre>
                   </li>
                 </ul>
+                <ul class="docs-notes">
+                  <li>See the 'Form icons' section below for guidance on adding icons to states.</li>
+                </ul>
               </footer>
             </div>
             <div class="docs-pattern">

--- a/docs/static/css/main.css
+++ b/docs/static/css/main.css
@@ -763,8 +763,14 @@ input[type="radio"] {
           @base-font-size-px
           @base-line-height-px
           @base-line-height
-          @mobile-max
-          @tablet-min
+          @bp-xs-max
+          @bp-sm-min
+          @bp-sm-max
+          @bp-med-min
+          @bp-med-max
+          @bp-lg-min
+          @bp-lg-max
+          @bp-xl-min
     - name: Colors
       codenotes:
         - |
@@ -777,6 +783,7 @@ input[type="radio"] {
           @link-underline-hover
           @link-text-active
           @link-underline-active
+          @table-border
           @thead-text
           @thead-bg
           @td-bg
@@ -943,13 +950,13 @@ input[type="radio"] {
 */
 .u-visually-hidden {
   position: absolute;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  height: 1px;
   width: 1px;
+  height: 1px;
+  border: 0;
   margin: -1px;
   padding: 0;
-  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
 }
 /* topdoc
   name: Inline block
@@ -1405,7 +1412,12 @@ input[type="radio"] {
   tags:
     - cf-core
 */
-@media only all and (max-width: 37.4375em) {
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
+@media only all and (max-width: 37.5em) {
   .u-hide-on-mobile {
     display: none;
   }
@@ -1413,7 +1425,12 @@ input[type="radio"] {
 .u-show-on-mobile {
   display: none;
 }
-@media only all and (max-width: 37.4375em) {
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
+}
+@media only all and (max-width: 37.5em) {
   .u-show-on-mobile {
     display: block;
   }
@@ -1515,19 +1532,19 @@ small {
         <h1>Example heading element</h1>
         <p class="h1">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h2.
+        - Responsive heading. At small screen sizes, displays as h2.
     - name: Heading level 2
       markup: |
         <h2>Example heading element</h2>
         <p class="h2">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h3.
+        - Responsive heading. At small screen sizes, displays as h3.
     - name: Heading level 3
       markup: |
         <h3>Example heading element</h3>
         <p class="h3">A non-heading element</p>
       notes:
-        - Responsive header. At mobile sizes, displays as h4.
+        - Responsive heading. At small screen sizes, displays as h4.
     - name: Heading level 4
       markup: |
         <h4>Example heading element</h4>
@@ -1540,110 +1557,227 @@ small {
       markup: |
         <h6>Example heading element</h6>
         <p class="h6">A non-heading element</p>
-    - name: Subheader
+    - name: Lead paragraph
       markup: |
-        <h1 class="subheader">Example subheader that's kinda long</h1>
-        <p class="subheader">Example subheader that's kinda long</p>
-    - name: Super header
+        <p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      notes:
+        - Responsive. Displays as an h3 on large screens; displays at h4 size (but still Regular weight) on small screens.
+    - name: Display heading (aka "superheading")
       markup: |
-        <h1 class="superheader">Example super header</h1>
-        <p class="superheader">Example super header</p>
+        <h1 class="superheading">Example display heading</h1>
   tags:
     - cf-core
 */
 body {
-  color: #5b3b57;
+  color: #212121;
   font-family: Georgia, "Times New Roman", serif;
   font-size: 100%;
   line-height: 1.375;
 }
 h1,
-.h1,
 h2,
-.h2,
 h3,
-.h3 {
+h4,
+h5,
+h6 {
+  margin-top: 0;
+}
+h1,
+.h1 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
+  margin-bottom: 0.44117647em;
+  font-size: 2.125em;
+  line-height: 1.25;
 }
 h1 em,
 .h1 em,
-h2 em,
-.h2 em,
-h3 em,
-.h3 em,
 h1 i,
-.h1 i,
-h2 i,
-.h2 i,
-h3 i,
-.h3 i {
+.h1 i {
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
 }
 .lt-ie9 h1 em,
 .lt-ie9 .h1 em,
-.lt-ie9 h2 em,
-.lt-ie9 .h2 em,
-.lt-ie9 h3 em,
-.lt-ie9 .h3 em,
 .lt-ie9 h1 i,
-.lt-ie9 .h1 i,
-.lt-ie9 h2 i,
-.lt-ie9 .h2 i,
-.lt-ie9 h3 i,
-.lt-ie9 .h3 i {
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
   font-style: normal !important;
 }
 h1 strong,
 .h1 strong,
-h2 strong,
-.h2 strong,
-h3 strong,
-.h3 strong,
 h1 b,
-.h1 b,
-h2 b,
-.h2 b,
-h3 b,
-.h3 b {
+.h1 b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
 }
 .lt-ie9 h1 strong,
 .lt-ie9 .h1 strong,
-.lt-ie9 h2 strong,
-.lt-ie9 .h2 strong,
-.lt-ie9 h3 strong,
-.lt-ie9 .h3 strong,
 .lt-ie9 h1 b,
-.lt-ie9 .h1 b,
-.lt-ie9 h2 b,
-.lt-ie9 .h2 b,
-.lt-ie9 h3 b,
-.lt-ie9 .h3 b {
+.lt-ie9 .h1 b {
   font-weight: normal !important;
 }
-h1,
-.h1 {
-  margin-top: 0;
-  margin-bottom: 0.47058824em;
-  font-size: 2.125em;
-  line-height: 1.29411765;
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
 }
-@media only all and (max-width: 37.4375em) {
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+p + h1,
+p + .h1,
+ul + h1,
+ul + .h1,
+ol + h1,
+ol + .h1,
+dl + h1,
+dl + .h1,
+figure + h1,
+figure + .h1,
+img + h1,
+img + .h1,
+table + h1,
+table + .h1,
+blockquote + h1,
+blockquote + .h1 {
+  margin-top: 1.76470588em;
+}
+@media only all and (max-width: 37.5em) {
   h1,
   .h1 {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
-    margin-top: 0;
-    margin-bottom: 0.73076923em;
+    margin-bottom: 0.57692308em;
     font-size: 1.625em;
-    line-height: 1.26923077;
+    line-height: 1.25;
   }
   h1 em,
   .h1 em,
@@ -1652,6 +1786,12 @@ h1,
     font-family: Arial, Arial, sans-serif;
     font-style: italic;
     font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
   }
   .lt-ie9 h1 em,
   .lt-ie9 .h1 em,
@@ -1673,17 +1813,11 @@ h1,
   .lt-ie9 .h1 b {
     font-weight: normal !important;
   }
-}
-@media only all and (max-width: 37.4375em) and only all and (max-width: 37.4375em) {
-  h1,
-  .h1 {
-    font-family: Arial, Arial, sans-serif;
-    font-style: normal;
-    font-weight: normal;
-    margin-top: 0;
-    margin-bottom: 0.95454545em;
-    font-size: 1.375em;
-    line-height: 1.27272727;
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
   }
   h1 em,
   .h1 em,
@@ -1692,6 +1826,12 @@ h1,
     font-family: Arial, Arial, sans-serif;
     font-style: italic;
     font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
   }
   .lt-ie9 h1 em,
   .lt-ie9 .h1 em,
@@ -1713,40 +1853,562 @@ h1,
   .lt-ie9 .h1 b {
     font-weight: normal !important;
   }
-}
-@media only all and (max-width: 37.4375em) and only all and (max-width: 37.4375em) and only all and (max-width: 37.4375em) {
-  h1,
-  .h1 {
-    margin-top: 0;
-    margin-bottom: 1.16666667em;
-    font-size: 1.125em;
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
-    font-weight: 500;
-    line-height: 1.22222222;
+    font-weight: bold;
   }
-  .lt-ie9 h1,
-  .lt-ie9 .h1 {
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
     font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
   }
 }
 h2,
 .h2 {
-  margin-top: 0;
-  margin-bottom: 0.73076923em;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.57692308em;
   font-size: 1.625em;
-  line-height: 1.26923077;
+  line-height: 1.25;
 }
-@media only all and (max-width: 37.4375em) {
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+p + h2,
+p + .h2,
+ul + h2,
+ul + .h2,
+ol + h2,
+ol + .h2,
+dl + h2,
+dl + .h2,
+figure + h2,
+figure + .h2,
+img + h2,
+img + .h2,
+table + h2,
+table + .h2,
+blockquote + h2,
+blockquote + .h2 {
+  margin-top: 1.73076923em;
+}
+h1 + h2,
+h1 + .h2,
+.h1 + h2,
+.h1 + .h2,
+h3 + h2,
+h3 + .h2,
+.h3 + h2,
+.h3 + .h2,
+h4 + h2,
+h4 + .h2,
+.h4 + h2,
+.h4 + .h2,
+h5 + h2,
+h5 + .h2,
+.h5 + h2,
+.h5 + .h2,
+h6 + h2,
+h6 + .h2,
+.h6 + h2,
+.h6 + .h2 {
+  margin-top: 1.15384615em;
+}
+@media only all and (max-width: 37.5em) {
   h2,
   .h2 {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: normal;
-    margin-top: 0;
-    margin-bottom: 0.95454545em;
+    margin-bottom: 0.68181818em;
     font-size: 1.375em;
-    line-height: 1.27272727;
+    line-height: 1.25;
   }
   h2 em,
   .h2 em,
@@ -1755,6 +2417,12 @@ h2,
     font-family: Arial, Arial, sans-serif;
     font-style: italic;
     font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
   }
   .lt-ie9 h2 em,
   .lt-ie9 .h2 em,
@@ -1776,40 +2444,595 @@ h2,
   .lt-ie9 .h2 b {
     font-weight: normal !important;
   }
-}
-@media only all and (max-width: 37.4375em) and only all and (max-width: 37.4375em) {
-  h2,
-  .h2 {
-    margin-top: 0;
-    margin-bottom: 1.16666667em;
-    font-size: 1.125em;
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
-    font-weight: 500;
-    line-height: 1.22222222;
+    font-weight: bold;
   }
-  .lt-ie9 h2,
-  .lt-ie9 .h2 {
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
     font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
   }
 }
 h3,
 .h3 {
-  margin-top: 0;
-  margin-bottom: 0.95454545em;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.68181818em;
   font-size: 1.375em;
-  line-height: 1.27272727;
+  line-height: 1.25;
 }
-@media only all and (max-width: 37.4375em) {
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+p + h3,
+p + .h3,
+ul + h3,
+ul + .h3,
+ol + h3,
+ol + .h3,
+dl + h3,
+dl + .h3,
+figure + h3,
+figure + .h3,
+img + h3,
+img + .h3,
+table + h3,
+table + .h3,
+blockquote + h3,
+blockquote + .h3,
+h1 + h3,
+h1 + .h3,
+.h1 + h3,
+.h1 + .h3,
+h2 + h3,
+h2 + .h3,
+.h2 + h3,
+.h2 + .h3,
+h4 + h3,
+h4 + .h3,
+.h4 + h3,
+.h4 + .h3,
+h5 + h3,
+h5 + .h3,
+.h5 + h3,
+.h5 + .h3,
+h6 + h3,
+h6 + .h3,
+.h6 + h3,
+.h6 + .h3 {
+  margin-top: 1.36363636em;
+}
+@media only all and (max-width: 37.5em) {
   h3,
   .h3 {
-    margin-top: 0;
-    margin-bottom: 1.16666667em;
-    font-size: 1.125em;
     font-family: Arial, Arial, sans-serif;
     font-style: normal;
     font-weight: 500;
-    line-height: 1.22222222;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
   }
   .lt-ie9 h3,
   .lt-ie9 .h3 {
@@ -1818,97 +3041,421 @@ h3,
 }
 h4,
 .h4 {
-  margin-top: 0;
-  margin-bottom: 1.16666667em;
-  font-size: 1.125em;
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: 500;
-  line-height: 1.22222222;
+  margin-bottom: 0.83333333em;
+  font-size: 1.125em;
+  line-height: 1.25;
 }
 .lt-ie9 h4,
 .lt-ie9 .h4 {
   font-weight: normal !important;
 }
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+p + h4,
+p + .h4,
+ul + h4,
+ul + .h4,
+ol + h4,
+ol + .h4,
+dl + h4,
+dl + .h4,
+figure + h4,
+figure + .h4,
+img + h4,
+img + .h4,
+table + h4,
+table + .h4,
+blockquote + h4,
+blockquote + .h4,
+h1 + h4,
+h1 + .h4,
+.h1 + h4,
+.h1 + .h4,
+h2 + h4,
+h2 + .h4,
+.h2 + h4,
+.h2 + .h4,
+h3 + h4,
+h3 + .h4,
+.h3 + h4,
+.h3 + .h4,
+h5 + h4,
+h5 + .h4,
+.h5 + h4,
+.h5 + .h4,
+h6 + h4,
+h6 + .h4,
+.h6 + h4,
+.h6 + .h4 {
+  margin-top: 1.66666667em;
+}
 h5,
+.h5 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+p + h5,
+p + .h5,
+ul + h5,
+ul + .h5,
+ol + h5,
+ol + .h5,
+dl + h5,
+dl + .h5,
+figure + h5,
+figure + .h5,
+img + h5,
+img + .h5,
+table + h5,
+table + .h5,
+blockquote + h5,
+blockquote + .h5,
+h1 + h5,
+h1 + .h5,
+.h1 + h5,
+.h1 + .h5,
+h2 + h5,
+h2 + .h5,
+.h2 + h5,
+.h2 + .h5,
+h3 + h5,
+h3 + .h5,
+.h3 + h5,
+.h3 + .h5,
+h4 + h5,
+h4 + .h5,
+.h4 + h5,
+.h4 + .h5,
+h6 + h5,
+h6 + .h5,
+.h6 + h5,
+.h6 + .h5 {
+  margin-top: 2.14285714em;
+}
 h6,
-.h5,
 .h6 {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+  margin-bottom: 1.25em;
+  font-size: 0.75em;
   letter-spacing: 1px;
+  line-height: 1.25;
   text-transform: uppercase;
 }
-.lt-ie9 h5,
 .lt-ie9 h6,
-.lt-ie9 .h5,
 .lt-ie9 .h6 {
   font-weight: normal !important;
 }
-h5,
-.h5 {
-  margin-top: 0;
-  margin-bottom: 0.35714286em;
-  font-size: 0.875em;
-  line-height: 1.57142857;
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
 }
-h6,
-.h6 {
-  margin-top: 0;
-  margin-bottom: 0.41666667em;
-  font-size: 0.75em;
-  line-height: 1.83333333;
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
 }
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+p + h6,
+p + .h6,
+ul + h6,
+ul + .h6,
+ol + h6,
+ol + .h6,
+dl + h6,
+dl + .h6,
+figure + h6,
+figure + .h6,
+img + h6,
+img + .h6,
+table + h6,
+table + .h6,
+blockquote + h6,
+blockquote + .h6,
+h1 + h6,
+h1 + .h6,
+.h1 + h6,
+.h1 + .h6,
+h2 + h6,
+h2 + .h6,
+.h2 + h6,
+.h2 + .h6,
+h3 + h6,
+h3 + .h6,
+.h3 + h6,
+.h3 + .h6,
+h4 + h6,
+h4 + .h6,
+.h4 + h6,
+.h4 + .h6,
+h5 + h6,
+h5 + .h6,
+.h5 + h6,
+.h5 + .h6 {
+  margin-top: 2.5em;
+}
+.lead-paragraph,
+.subheader,
 .subheader {
-  margin-top: 0;
-  margin-bottom: 1.16666667em;
-  font-size: 1.125em;
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: normal;
-  line-height: 1.22222222;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+  margin-top: 1.36363636em;
+  margin-bottom: 0.83333333em;
 }
-.subheader em,
-.subheader i {
+.lead-paragraph em,
+.lead-paragraph i {
   font-family: Arial, Arial, sans-serif;
   font-style: italic;
   font-weight: normal;
 }
-.lt-ie9 .subheader em,
-.lt-ie9 .subheader i {
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
   font-style: normal !important;
 }
-.subheader strong,
-.subheader b {
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
 }
-.lt-ie9 .subheader strong,
-.lt-ie9 .subheader b {
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
   font-weight: normal !important;
 }
-.superheader {
-  margin-bottom: 0.1875em;
-  font-size: 3em;
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+.superheading,
+.superheader,
+.superheader {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.41666667em;
+  font-size: 3em;
   line-height: 1.25;
 }
-.lt-ie9 .superheader {
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
   font-weight: normal !important;
 }
 /* topdoc
-  name: Margins
+  name: Body copy element vertical margins
   family: cf-core
   patterns:
     - name: Consistent vertical margins
       notes:
-        - "Assumes that the font size of each of these items remains the default."
+        - Applies 15px bottom margin to all p, ul, ol, dl, figure, table, and blockquote elements.
+        - Applies -5px top margin to lists following paragraphs to reduce margin between them to 10px.
+        - Applies 8px bottom margin to list items that are not within a nav element.
+        - Assumes that the font size of each of these items remains the default.
       markup: |
         <p>Paragraph margin example</p>
+        <p>Paragraph margin example</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
         <p>Paragraph margin example</p>
   tags:
     - cf-core
@@ -1917,10 +3464,21 @@ p,
 ul,
 ol,
 dl,
+figure,
 table,
-figure {
+blockquote {
   margin-top: 0;
-  margin-bottom: 1.25em;
+  margin-bottom: 0.9375em;
+}
+p + ul,
+p + ol {
+  margin-top: -0.3125em;
+}
+:not(nav) li {
+  margin-bottom: 0.5em;
+}
+.lt-ie9 nav li {
+  margin-bottom: 0;
 }
 /* topdoc
   name: Default link
@@ -1950,20 +3508,20 @@ figure {
 a {
   border-width: 0;
   border-style: dotted;
-  border-color: #c7336e;
-  color: #c7336e;
+  border-color: #0071bc;
+  color: #0071bc;
   text-decoration: none;
 }
 a:visited,
 a.visited {
-  border-color: #cf447c;
-  color: #cf447c;
+  border-color: #4c2c92;
+  color: #4c2c92;
 }
 a:hover,
 a.hover {
   border-style: solid;
-  border-color: #9e2958;
-  color: #9e2958;
+  border-color: #205493;
+  color: #205493;
 }
 a:focus,
 a.focus {
@@ -1973,8 +3531,8 @@ a.focus {
 a:active,
 a.active {
   border-style: solid;
-  border-color: #8a234c;
-  color: #8a234c;
+  border-color: #046b99;
+  color: #046b99;
 }
 /* topdoc
   name: Underlined links
@@ -2054,16 +3612,32 @@ nav a {
   patterns:
     - name: Unordered list
       markup: |
+        <p>Paragraph example for visual reference</p>
         <ul>
-            <li>List item</li>
-            <li>List item</li>
-            <li>List item</li>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
         </ul>
+    - name: Ordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ol>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ol>
   tags:
     - cf-core
 */
 ul {
+  padding-left: 2em;
   list-style: square;
+}
+ol {
+  padding-left: 1.9375em;
+}
+ol > li {
+  padding-left: 0.0625em;
 }
 /* topdoc
   name: Tables
@@ -2081,52 +3655,22 @@ ul {
             </thead>
             <tbody>
                 <tr>
-                    <th>Row 1 header</th>
+                    <td>Row 1, column 1</td>
                     <td>Row 1, column 2</td>
                     <td>Row 1, column 3</td>
                 </tr>
                 <tr>
-                    <th>Row 2 header</th>
+                    <td>Row 2, column 1</td>
                     <td>Row 2, column 2</td>
                     <td>Row 2, column 3</td>
                 </tr>
                 <tr>
-                    <th>Row 3 header</th>
+                    <td>Row 3, column 1</td>
                     <td>Row 3, column 2</td>
                     <td>Row 3, column 3</td>
                 </tr>
             </tbody>
         </table>
-    - name: Compact table
-      markup: |
-        <table class="compact-table">
-            <thead>
-                <tr>
-                    <th>Column 1 header</th>
-                    <th>Column 2 header</th>
-                    <th>Column 3 header</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <th>Row 1 header</th>
-                    <td>Row 1, column 2</td>
-                    <td>Row 1, column 3</td>
-                </tr>
-                <tr>
-                    <th>Row 2 header</th>
-                    <td>Row 2, column 2</td>
-                    <td>Row 2, column 3</td>
-                </tr>
-                <tr>
-                    <th>Row 3 header</th>
-                    <td>Row 3, column 2</td>
-                    <td>Row 3, column 3</td>
-                </tr>
-            </tbody>
-        </table>
-      notes:
-        - Reduces cell padding to 10px.
   tags:
     - cf-core
 */
@@ -2145,6 +3689,10 @@ table i {
 .lt-ie9 table i {
   font-style: normal !important;
 }
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
 table strong,
 table b {
   font-family: Arial, Arial, sans-serif;
@@ -2155,23 +3703,166 @@ table b {
 .lt-ie9 table b {
   font-weight: normal !important;
 }
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
 th,
 td {
-  padding: 0.75em 0.9375em;
-  background: #eee4ed;
+  padding: 0.625em;
 }
 thead th,
 thead td {
-  color: #ffffff;
-  background: #5b3b57;
+  color: #212121;
+  background: #f1f1f1;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
 }
-tbody > tr:nth-child(odd) > th,
-tbody > tr:nth-child(odd) > td {
-  background: #f4edf3;
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
 }
-.compact-table th,
-.compact-table td {
-  padding: 0.4375em 0.625em;
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+thead,
+tbody tr {
+  border-bottom: 1px solid #5b616b;
 }
 th {
   font-family: Arial, Arial, sans-serif;
@@ -2180,6 +3871,70 @@ th {
   text-align: left;
 }
 .lt-ie9 th {
+  font-weight: normal !important;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
+}
+tbody th {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
   font-weight: normal !important;
 }
 /* topdoc
@@ -2208,72 +3963,19 @@ th {
     - cf-core
 */
 blockquote {
-  margin: 1.25em;
+  margin-right: 0.9375em;
+  margin-left: 0.9375em;
 }
-@media only all and (min-width: 37.5em) {
+@media only all and (min-width: 37.5625em) {
   blockquote {
-    margin: 1.75em 2.5em;
+    margin-right: 1.875em;
+    margin-left: 1.875em;
   }
 }
-/* topdoc
-    name: Fieldsets
-    family: cf-core
-    notes:
-      - "Visit https://github.com/cfpb/cf-forms for advanced fieldset patterns."
-    patterns:
-    - name: Default fieldset legend
-      markup: |
-        <fieldset>
-            <legend>Fieldset legend</legend>
-            <label for="name">
-                Label
-            </label>
-            <input type="text" id="name" value="" placeholder="Placeholder text">
-        </fieldset>
-    tags:
-    - cf-core
-*/
-legend {
-  font-family: Arial, Arial, sans-serif;
-  font-style: normal;
-  font-weight: normal;
-  margin-top: 0;
-  margin-bottom: 0.95454545em;
-  font-size: 1.375em;
-  line-height: 1.27272727;
-}
-legend em,
-legend i {
-  font-family: Arial, Arial, sans-serif;
-  font-style: italic;
-  font-weight: normal;
-}
-.lt-ie9 legend em,
-.lt-ie9 legend i {
-  font-style: normal !important;
-}
-legend strong,
-legend b {
-  font-family: Arial, Arial, sans-serif;
-  font-style: normal;
-  font-weight: bold;
-}
-.lt-ie9 legend strong,
-.lt-ie9 legend b {
-  font-weight: normal !important;
-}
-@media only all and (max-width: 37.4375em) {
-  legend {
-    margin-top: 0;
-    margin-bottom: 1.16666667em;
-    font-size: 1.125em;
-    font-family: Arial, Arial, sans-serif;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 1.22222222;
-  }
-  .lt-ie9 legend {
-    font-weight: normal !important;
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
   }
 }
 /* topdoc
@@ -2315,11 +4017,47 @@ label i {
 .lt-ie9 label i {
   font-style: normal !important;
 }
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
 label strong,
 label b {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
 }
 .lt-ie9 label strong,
 .lt-ie9 label b {
@@ -2408,7 +4146,7 @@ select[multiple] {
   font-family: Arial, sans-serif;
   font-size: 1em;
   background: #ffffff;
-  border: 1px solid #5b3b57;
+  border: 1px solid #5b616b;
   border-radius: 0;
   vertical-align: top;
   -webkit-appearance: none;
@@ -2433,8 +4171,8 @@ textarea:focus,
 textarea.focus,
 select[multiple]:focus,
 select[multiple].focus {
-  border: 1px solid #c7336e;
-  outline: 1px solid #c7336e;
+  border: 1px solid #3e94cf;
+  outline: 1px solid #3e94cf;
   outline-offset: 0;
   -webkit-box-shadow: none;
   box-shadow: none;
@@ -2488,7 +4226,3497 @@ figure img {
   vertical-align: middle;
 }
 .figure__bordered img {
-  border: 1px solid #5b3b57;
+  border: 1px solid #d6d7d9;
+}
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Core Less file
+   ========================================================================== */
+/* ==========================================================================
+   Capital Framework
+   Less variables
+   ========================================================================== */
+/* topdoc
+  name: Theme variables
+  family: cf-core
+  notes:
+    - "The following color and sizing variables are exposed, allowing you to
+       easily override them before compiling."
+  patterns:
+    - name: Sizing
+      codenotes:
+        - |
+          @base-font-size-px
+          @base-line-height-px
+          @base-line-height
+          @bp-xs-max
+          @bp-sm-min
+          @bp-sm-max
+          @bp-med-min
+          @bp-med-max
+          @bp-lg-min
+          @bp-lg-max
+          @bp-xl-min
+    - name: Colors
+      codenotes:
+        - |
+          @text
+          @link-text
+          @link-underline
+          @link-text-visited
+          @link-underline-visited
+          @link-text-hover
+          @link-underline-hover
+          @link-text-active
+          @link-underline-active
+          @table-border
+          @thead-text
+          @thead-bg
+          @td-bg
+          @td-bg-alt
+          @input-bg
+          @input-border
+          @input-border-focus
+          @input-placeholder
+          @figure__bordered
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Media queries
+   ========================================================================== */
+/* topdoc
+  name: Media query mixins
+  family: cf-core
+  notes:
+    - "These mixins allow us to write consistent media queries using pixel
+      values, which are easier to remember. The mixins handle converting the
+      pixels into em's."
+  patterns:
+    - name: "min-width/max-width media queries"
+      codenotes:
+        - ".respond-to-min(@bp, @rules)"
+        - ".respond-to-max(@bp, @rules)"
+      notes:
+        - "@bp: the breakpoint size in pixels. It will get converted into em's."
+        - "@rules: a CSS or Less ruleset. Note that it can contain the full set
+          of Less features."
+    - name: "min-width/max-width media query usage"
+      codenotes:
+        - |
+            .respond-to-min(768px, {
+                .title {
+                    font-size: 2em;
+                }
+            });
+
+            Compiles to:
+
+            @media only all and (min-width: 48em) {
+                .title {
+                    font-size: 2em;
+                }
+            }
+    - name: "min-width/max-width media query range"
+      codenotes:
+        - ".respond-to-range(@bp1, @bp2, @rules)"
+      notes:
+        - "@bp1: the min-width breakpoint size in pixels.
+          It will get converted into em's."
+        - "@bp2: the max-width breakpoint size in pixels.
+          It will get converted into em's."
+        - "@rules: a CSS or Less ruleset. Note that it can contain the full set
+          of Less features."
+    - name: "min-width/max-width media query range usage"
+      codenotes:
+        - |
+            .respond-to-range(320px, 768px, {
+                .title {
+                    font-size: 2em;
+                }
+            });
+
+            Compiles to:
+
+            @media only all and (min-width: 20em) and (max-width: 48em) {
+                .title {
+                    font-size: 2em;
+                }
+            }
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: EOF
+  eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Utilities
+   ========================================================================== */
+/* topdoc
+  name: JS-only
+  family: cf-core
+  patterns:
+    - name: Setup
+      codenotes:
+        - <html class="no-js">
+        - |
+            <script>
+                // Confirm availability of JS and remove no-js class from html
+                var docElement = document.documentElement;
+                docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2');
+            </script>
+      notes:
+        - "First add the .no-js class to the HTML element."
+        - "Then add the script to your HEAD which removes the .no-js class when
+           JS is available."
+    - name: Utility class
+      codenotes:
+        - .u-js-only;
+      notes:
+        - "Hide stuff when JavaScript isn't available. Depends on having a small
+           script in the HEAD of your HTML document that removes a .no-js class."
+  tags:
+    - cf-core
+*/
+.no-js .u-js-only {
+  display: none !important;
+}
+/* topdoc
+  name: Clearfix
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <div class="u-clearfix">
+            <div style="float:left; width:100%; height:60px; background:black;"></div>
+        </div>
+      codenotes:
+        - .u-clearfix;
+      notes:
+        - "Use this class to clear floats. For example, without .u-clearfix the
+           black box would spill into the markup section."
+        - "More information: http://css-tricks.com/snippets/css/clear-fix/"
+  tags:
+    - cf-core
+*/
+.u-clearfix:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.lt-ie8 .u-clearfix {
+  zoom: 1;
+}
+/* topdoc
+  name: Visually hidden
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <h1>
+            <a href="#">
+                <span class="cf-icon cf-icon-twitter-square"></span>
+                <span class="u-visually-hidden">Share on Twitter</span>
+            </a>
+        </h1>
+      codenotes:
+        - .u-visually-hidden;
+      notes:
+        - "Use this class to hide something from view while keeping it
+          accessible to screen readers."
+  tags:
+    - cf-core
+*/
+.u-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  border: 0;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+/* topdoc
+  name: Inline block
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - .u-inline-block;
+      notes:
+        - "Also adds a .lt-ie8 class to hack inline-block for IE 7 and below."
+  tags:
+    - cf-core
+*/
+.u-inline-block {
+  display: inline-block;
+}
+.lt-ie8 .u-inline-block {
+  display: inline;
+}
+/* topdoc
+  name: Floating right
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - .u-right;
+      notes:
+        - "IE7 float: right drop bug fixes:"
+        - "1. If the float: right follows an element in the html structure that
+          should be to its left (and not above it), then that preceding
+          element(s) must be float: left.
+          http://stackoverflow.com/questions/10981767/clean-css-fix-of-ie7s-float-right-drop-bug#answer-11437688"
+        - "2. Simply change the markup order so that the element floating right
+          comes before the element to its left."
+  tags:
+    - cf-core
+*/
+.u-right {
+  float: right;
+}
+/* topdoc
+  name: Break word
+  family: cf-core
+  patterns:
+    - name: Utility class
+      markup: |
+        <div style="width: 100px;">
+            This link should break:
+            <br>
+            <a class="u-break-word" href="#">
+                something@something.com
+            </a>
+            <br>
+            <br>
+            This link should not:
+            <br>
+            <a href="#">
+                something@something.com
+            </a>
+        </div>
+      codenotes:
+        - .u-break-word
+      notes:
+        - "Use this on elements where you need the words to break when confined
+           to small containers."
+        - "This only works in IE8 when the element with the .u-break-word class
+           has layout. See <http://stackoverflow.com/questions/3997223/word-wrapbreak-word-not-working-in-ie8>
+           for more information."
+  tags:
+    - cf-core
+*/
+.u-break-word {
+  word-break: break-all;
+}
+/* topdoc
+  name: Align with button
+  family: cf-core
+  patterns:
+    - name: Utility class
+      codenotes:
+        - ".u-align-with-btn(@font-size: @base-font-size-px);"
+      notes:
+        - "Adds top padding (among other things) to help alignment with buttons."
+        - "If you pass no arguments then the padding will be calculated using
+          @base-font-size-px."
+        - "Pass one argument to use a custom font size to calculate the top
+          padding."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Flexible proportional containers
+  family: cf-core
+  notes:
+    - "Utilizes intrinsic ratios to create a flexible container that retains its
+      aspect ratio. When image tags scale they retain their aspect ratio, but if
+      you need a flexible video you will need to use this mixin."
+    - "You can read more about intrinsic rations here:
+      http://alistapart.com/article/creating-intrinsic-ratios-for-video"
+  patterns:
+    - name: Default example
+      markup: |
+        <div class="u-flexible-container">
+            <video
+              class="u-flexible-container_inner"
+              style="background:#75787B;"
+              controls>
+            </video>
+        </div>
+      notes:
+        - "Defaults to a 16:19 ratio."
+        - "Original mixin credit: https://gist.github.com/craigmdennis/6655047"
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container
+            .u-flexible-container_inner
+    - name: Background image examples
+      markup: |
+        <div class="u-flexible-container"
+             style="
+               background-image:url(http://placekitten.com/700/394);
+               background-position: center center;
+             ">
+        </div>
+        <div class="u-flexible-container"
+             style="
+               background-image:url(http://placekitten.com/700/394);
+               background-position: center center;
+               background-size: cover;
+             ">
+        </div>
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container
+      notes:
+        - "If you're not using the video or object elements and all you need is
+          a proportionally cropped or scaling background image with a fluid
+          container then you can leave out u-flexible-container_inner."
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+    - name: 4-3 modifier
+      markup: |
+        <div class="u-flexible-container u-flexible-container__4-3">
+            <video
+              class="u-flexible-container_inner"
+              style="background:#75787B;"
+              controls>
+            </video>
+        </div>
+      codenotes:
+        - |
+          Structural sheat sheet:
+          -----------------------
+          .u-flexible-container.u-flexible-container__4-3
+            .u-flexible-container_inner
+      notes:
+        - "Create your own aspect ratios by using this modifier as an example."
+        - "Note that inline style usage is being used for demo purposes only.
+          Please do not use inline styles."
+  tags:
+    - cf-core
+*/
+.u-flexible-container {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+}
+.u-flexible-container_inner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.u-flexible-container__4-3 {
+  position: relative;
+  padding-bottom: 75%;
+  height: 0;
+}
+/* topdoc
+  name: Link mixins
+  family: cf-core
+  patterns:
+    - codenotes:
+        - .u-link__colors();
+      notes:
+        - "Pass this mixin no arguments to color your link states with the
+          following defaults: :link (default state) pacific, :hover pacific-50,
+          :focus: pacific, :visited teal, :active navy."
+    - codenotes:
+        - .u-link__colors(@c);
+      notes:
+        - "Pass this mixin one color to be used on all of the following
+          states of your link; :link (default state), :visited, :hover, :focus,
+          :active."
+    - codenotes:
+        - .u-link__colors(@c, @h);
+      notes:
+        - "Pass this mixin two colors to use the first color for the :link,
+          :visited, and :active states, and the second color for the :hover and
+          :focus states."
+    - codenotes:
+        - .u-link__colors(@c, @v, @h, @f, @a);
+      notes:
+        - "Pass this mixin five colors in 'love/hate' mnemonic order to color
+          :link, :visited, :hover, :focus, and :active states respectively."
+        - "Even though this mixin is basically the same as
+          .u-link__colors-base(@c, @v, @h, @f, @a); we encourage you to use
+          .u-link__colors(@c, @v, @h, @f, @a) to promote consistency."
+    - codenotes:
+        - .u-link__colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba);
+      notes:
+        - "Allows you to color text and the borders separately."
+        - "The first five colors in 'love/hate' mnemonic order will color text
+          for the :link, :visited, :hover, :focus, and :active states
+          respectively. The last five colors in 'love/hate' mnemonic order will
+          color the borders for the :link, :visited, :hover, :focus, and :active
+          states respectively."
+        - "Even though this mixin is basically the same as
+          .u-link__colors-base(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba); we
+          encourage you to use .u-link__colors(@c, @v, @h, @f, @a, @bc, @bv, @bh, @bf, @ba)
+          to promote consistency."
+    - codenotes:
+        - .u-link__colors-base(@c, @v, @h, @f, @a);
+      notes:
+        - "This is the base mixin that all .u-link__colors() mixins use. Please
+          refrain from using this mixin directly in order to promote a
+          consistent use of mixin names for coloring links throughout this
+          project. Remember that if you need to set colors for all states of a
+          link you should use .u-link__colors(@c, @v, @h, @f, @a)."
+    - codenotes:
+        - .u-link__border();
+      notes:
+        - "Forces the default bottom border on the :link and :hover states."
+    - codenotes:
+        - .u-link__no-border();
+      notes:
+        - "Turn off the default bottom border on the :link and :hover states."
+    - codenotes:
+        - .u-link__hover-border();
+      notes:
+        - "Turn off the default bottom border on the :link state and force a
+          bottom border on the :hover state."
+    - codenotes:
+        - .u-link-child__hover();
+      notes:
+        - "When a link has child elements you may want only certain children to
+          change color when the parent link is hovered.
+          Pass no arguments to this mixin to color the child element pacific
+          when the parent link is hovered."
+    - codenotes:
+        - .u-link-child__hover(@c);
+      notes:
+        - "Pass this mixin one color to color the child element when the parent
+          link is hovered."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Margin utilities
+  family: cf-core
+  patterns:
+    - name: Utility classes
+      codenotes:
+        - .u-m<p><#>;
+      notes:
+        - "Replace <p> with the first letter of the position ('t' for top or 'b'
+           for bottom) and <#> with the pixel value of the margin you want."
+        - "Available values: 0, 5, 10, 15, 20, 30, 45, 60."
+  tags:
+    - cf-core
+*/
+.u-mt0 {
+  margin-top: 0 !important;
+}
+.u-mb0 {
+  margin-bottom: 0 !important;
+}
+.u-mt5 {
+  margin-top: 5px !important;
+}
+.u-mb5 {
+  margin-bottom: 5px !important;
+}
+.u-mt10 {
+  margin-top: 10px !important;
+}
+.u-mb10 {
+  margin-bottom: 10px !important;
+}
+.u-mt15 {
+  margin-top: 15px !important;
+}
+.u-mb15 {
+  margin-bottom: 15px !important;
+}
+.u-mt20 {
+  margin-top: 20px !important;
+}
+.u-mb20 {
+  margin-bottom: 20px !important;
+}
+.u-mt30 {
+  margin-top: 30px !important;
+}
+.u-mb30 {
+  margin-bottom: 30px !important;
+}
+.u-mt45 {
+  margin-top: 45px !important;
+}
+.u-mb45 {
+  margin-bottom: 45px !important;
+}
+.u-mt60 {
+  margin-top: 60px !important;
+}
+.u-mb60 {
+  margin-bottom: 60px !important;
+}
+/* topdoc
+  name: Width utilities
+  family: cf-core
+  patterns:
+    - name: Percent-based
+      markup: |
+        <div class="u-w100pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w100pct</code>
+        </div>
+        <div class="u-w90pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w90pct</code>
+        </div>
+        <div class="u-w80pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w80pct</code>
+        </div>
+        <div class="u-w70pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w70pct</code>
+        </div>
+        <div class="u-w60pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w60pct</code>
+        </div>
+        <div class="u-w50pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w50pct</code>
+        </div>
+        <div class="u-w40pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w40pct</code>
+        </div>
+        <div class="u-w30pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w30pct</code>
+        </div>
+        <div class="u-w20pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w20pct</code>
+        </div>
+        <div class="u-w10pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w10pct</code>
+        </div>
+        <div class="u-w75pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w75pct</code>
+        </div>
+        <div class="u-w25pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w25pct</code>
+        </div>
+        <div class="u-w66pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w66pct</code>
+        </div>
+        <div class="u-w33pct" style="background: #f4edf3; margin-bottom: 1px;">
+            <code>.u-w33pct</code>
+        </div>
+      notes:
+        - "Inline styles are for demonstration purposes only, please don't use
+           them."
+  tags:
+    - cf-core
+*/
+.u-w100pct {
+  width: 100%;
+}
+.u-w90pct {
+  width: 90%;
+}
+.u-w80pct {
+  width: 80%;
+}
+.u-w70pct {
+  width: 70%;
+}
+.u-w60pct {
+  width: 60%;
+}
+.u-w50pct {
+  width: 50%;
+}
+.u-w40pct {
+  width: 40%;
+}
+.u-w30pct {
+  width: 30%;
+}
+.u-w20pct {
+  width: 20%;
+}
+.u-w10pct {
+  width: 10%;
+}
+.u-w75pct {
+  width: 75%;
+}
+.u-w25pct {
+  width: 25%;
+}
+.u-w66pct {
+  width: 66.66666667%;
+}
+.u-w33pct {
+  width: 33.33333333%;
+}
+/* topdoc
+  name: Width-specific display
+  family: cf-core
+  patterns:
+    - name: Show on mobile
+      markup: |
+        <section>
+            <p>The the text in the box below is visible only at widths less than 600px</p>
+            <div style="border: 1px solid black; height: 22px; padding: 5px;">
+                <p class="u-show-on-mobile">Visible on mobile</p>
+            </div>
+        </section>
+      codenotes:
+        - ".u-show-on-mobile"
+        - "Uses 'display:block' to toggle display. Would need to be extended
+          for inline use cases."
+      notes:
+        - "Displays an element only at mobile widths."
+    - name: Hide on mobile
+      markup: |
+        <section>
+            <p>The text in the box below is hidden at widths less than 600px</p>
+            <div style="border: 1px solid black; height: 22px; padding: 5px;">
+                <p class="u-hide-on-mobile">Hidden on mobile</p>
+            </div>
+        </section>
+      codenotes:
+        - ".u-hide-on-mobile"
+      notes:
+        - "Hides an element at mobile widths"
+  tags:
+    - cf-core
+*/
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .u-hide-on-mobile {
+    display: none;
+  }
+}
+.u-show-on-mobile {
+  display: none;
+}
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .u-show-on-mobile {
+    display: block;
+  }
+}
+/* topdoc
+  name: Small text utility
+  family: cf-core
+  patterns:
+    - name: .u-small-text (utility class)
+      markup: |
+        Lorem ipsum<br>
+        <span class="u-small-text">dolor sit amet</span>
+      codenotes:
+        - ".u-small-text"
+      notes:
+        - "14px text."
+        - "The utility class should only be used when the default text size is
+           16px. For example you wouldn't want to use the class inside of an
+           `h1` because the `font-size` in the `h1` will make `.u-small-text`
+           bigger than it should be. See the docs for the `.u-small-text()`
+           mixin."
+    - name: .u-small-text() (Less mixin)
+      codenotes:
+        - ".u-small-text(@context)"
+        - |
+          // Mixin usage:
+          .example {
+            font-size: unit(20px / @base-font-size-px, em);
+            small {
+              .u-small-text(20px);
+            }
+          }
+          // Compiles to:
+          .example {
+            font-size: 1.25em;
+          }
+          .example small {
+            font-size: 0.7em;
+          }
+      notes:
+        - "This mixin enables you to easily create consistent small text by
+           passing the context `font-size`."
+  tags:
+    - cf-core
+*/
+.u-small-text {
+  font-size: 0.875em;
+}
+small {
+  font-size: 0.875em;
+}
+/* topdoc
+    name: EOF
+    eof: true
+*/
+/* ==========================================================================
+   Capital Framework
+   Base styles
+   ========================================================================== */
+/* topdoc
+  name: Webfonts
+  family: cf-core
+  patterns:
+    - name: Webfont mixins and variables
+      codenotes:
+        - ".webfont-regular()"
+        - ".webfont-italic()"
+        - ".webfont-medium()"
+        - ".webfont-demi()"
+      notes:
+        - "Use these mixins to easily add the your preferred font family to your
+          elements."
+        - "To use your own fonts in the webfont mixins, set your own font with the
+          @webfont-regular/italic/medium/demi variables."
+        - "To avoid faux bold and italics,
+          you must use the font family name for that particular style.
+          For example, when defining an italic in Helvetica
+          you need to use the Helvetica Italic font family.
+          Use the mixins when setting bold or italic text as they also
+          set the appropriate font-weight and font-style."
+        - "These mixins also add the appropriate .lt-ie9 overrides.
+          .lt-ie9 overrides are necessary to override font-style and font-weight
+          each time the webfont is used. These overrides are built into the webfont
+          mixins so you get them automatically. Note that this requires you to
+          use conditional classes on the <html> element:
+          https://github.com/h5bp/html5-boilerplate/blob/v4.3.0/doc/html.md#conditional-html-classes."
+  tags:
+    - cf-core
+*/
+/* topdoc
+  name: Type hierarchy
+  family: cf-core
+  patterns:
+    - name: Default body type
+      markup: |
+        <p>Lorem ipsum dolor sit amet, <em>consectetur adipisicing elit</em>, sed do eiusmod <strong>tempor incididunt</strong> ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+    - name: Heading level 1
+      markup: |
+        <h1>Example heading element</h1>
+        <p class="h1">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h2.
+    - name: Heading level 2
+      markup: |
+        <h2>Example heading element</h2>
+        <p class="h2">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h3.
+    - name: Heading level 3
+      markup: |
+        <h3>Example heading element</h3>
+        <p class="h3">A non-heading element</p>
+      notes:
+        - Responsive heading. At small screen sizes, displays as h4.
+    - name: Heading level 4
+      markup: |
+        <h4>Example heading element</h4>
+        <p class="h4">A non-heading element</p>
+    - name: Heading level 5
+      markup: |
+        <h5>Example heading element</h5>
+        <p class="h5">A non-heading element</p>
+    - name: Heading level 6
+      markup: |
+        <h6>Example heading element</h6>
+        <p class="h6">A non-heading element</p>
+    - name: Lead paragraph
+      markup: |
+        <p class="lead-paragraph">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+      notes:
+        - Responsive. Displays as an h3 on large screens; displays at h4 size (but still Regular weight) on small screens.
+    - name: Display heading (aka "superheading")
+      markup: |
+        <h1 class="superheading">Example display heading</h1>
+  tags:
+    - cf-core
+*/
+body {
+  color: #212121;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 100%;
+  line-height: 1.375;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 0;
+}
+h1,
+.h1 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.44117647em;
+  font-size: 2.125em;
+  line-height: 1.25;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+h1 em,
+.h1 em,
+h1 i,
+.h1 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+.lt-ie9 h1 em,
+.lt-ie9 .h1 em,
+.lt-ie9 h1 i,
+.lt-ie9 .h1 i {
+  font-style: normal !important;
+}
+h1 strong,
+.h1 strong,
+h1 b,
+.h1 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h1 strong,
+.lt-ie9 .h1 strong,
+.lt-ie9 h1 b,
+.lt-ie9 .h1 b {
+  font-weight: normal !important;
+}
+p + h1,
+p + .h1,
+ul + h1,
+ul + .h1,
+ol + h1,
+ol + .h1,
+dl + h1,
+dl + .h1,
+figure + h1,
+figure + .h1,
+img + h1,
+img + .h1,
+table + h1,
+table + .h1,
+blockquote + h1,
+blockquote + .h1 {
+  margin-top: 1.76470588em;
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h1,
+  .h1 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.57692308em;
+    font-size: 1.625em;
+    line-height: 1.25;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  h1 em,
+  .h1 em,
+  h1 i,
+  .h1 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h1 em,
+  .lt-ie9 .h1 em,
+  .lt-ie9 h1 i,
+  .lt-ie9 .h1 i {
+    font-style: normal !important;
+  }
+  h1 strong,
+  .h1 strong,
+  h1 b,
+  .h1 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h1 strong,
+  .lt-ie9 .h1 strong,
+  .lt-ie9 h1 b,
+  .lt-ie9 .h1 b {
+    font-weight: normal !important;
+  }
+  p + h1,
+  p + .h1,
+  ul + h1,
+  ul + .h1,
+  ol + h1,
+  ol + .h1,
+  dl + h1,
+  dl + .h1,
+  figure + h1,
+  figure + .h1,
+  img + h1,
+  img + .h1,
+  table + h1,
+  table + .h1,
+  blockquote + h1,
+  blockquote + .h1 {
+    margin-top: 1.73076923em;
+  }
+  h2 + h1,
+  h2 + .h1,
+  .h2 + h1,
+  .h2 + .h1,
+  h3 + h1,
+  h3 + .h1,
+  .h3 + h1,
+  .h3 + .h1,
+  h4 + h1,
+  h4 + .h1,
+  .h4 + h1,
+  .h4 + .h1,
+  h5 + h1,
+  h5 + .h1,
+  .h5 + h1,
+  .h5 + .h1,
+  h6 + h1,
+  h6 + .h1,
+  .h6 + h1,
+  .h6 + .h1 {
+    margin-top: 1.15384615em;
+  }
+}
+h2,
+.h2 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.57692308em;
+  font-size: 1.625em;
+  line-height: 1.25;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+h2 em,
+.h2 em,
+h2 i,
+.h2 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+.lt-ie9 h2 em,
+.lt-ie9 .h2 em,
+.lt-ie9 h2 i,
+.lt-ie9 .h2 i {
+  font-style: normal !important;
+}
+h2 strong,
+.h2 strong,
+h2 b,
+.h2 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h2 strong,
+.lt-ie9 .h2 strong,
+.lt-ie9 h2 b,
+.lt-ie9 .h2 b {
+  font-weight: normal !important;
+}
+p + h2,
+p + .h2,
+ul + h2,
+ul + .h2,
+ol + h2,
+ol + .h2,
+dl + h2,
+dl + .h2,
+figure + h2,
+figure + .h2,
+img + h2,
+img + .h2,
+table + h2,
+table + .h2,
+blockquote + h2,
+blockquote + .h2 {
+  margin-top: 1.73076923em;
+}
+h1 + h2,
+h1 + .h2,
+.h1 + h2,
+.h1 + .h2,
+h3 + h2,
+h3 + .h2,
+.h3 + h2,
+.h3 + .h2,
+h4 + h2,
+h4 + .h2,
+.h4 + h2,
+.h4 + .h2,
+h5 + h2,
+h5 + .h2,
+.h5 + h2,
+.h5 + .h2,
+h6 + h2,
+h6 + .h2,
+.h6 + h2,
+.h6 + .h2 {
+  margin-top: 1.15384615em;
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h2,
+  .h2 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    margin-bottom: 0.68181818em;
+    font-size: 1.375em;
+    line-height: 1.25;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  h2 em,
+  .h2 em,
+  h2 i,
+  .h2 i {
+    font-family: Arial, Arial, sans-serif;
+    font-style: italic;
+    font-weight: normal;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  .lt-ie9 h2 em,
+  .lt-ie9 .h2 em,
+  .lt-ie9 h2 i,
+  .lt-ie9 .h2 i {
+    font-style: normal !important;
+  }
+  h2 strong,
+  .h2 strong,
+  h2 b,
+  .h2 b {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: bold;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h2 strong,
+  .lt-ie9 .h2 strong,
+  .lt-ie9 h2 b,
+  .lt-ie9 .h2 b {
+    font-weight: normal !important;
+  }
+  p + h2,
+  p + .h2,
+  ul + h2,
+  ul + .h2,
+  ol + h2,
+  ol + .h2,
+  dl + h2,
+  dl + .h2,
+  figure + h2,
+  figure + .h2,
+  img + h2,
+  img + .h2,
+  table + h2,
+  table + .h2,
+  blockquote + h2,
+  blockquote + .h2 {
+    margin-top: 1.36363636em;
+  }
+}
+h3,
+.h3 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+h3 em,
+.h3 em,
+h3 i,
+.h3 i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+.lt-ie9 h3 em,
+.lt-ie9 .h3 em,
+.lt-ie9 h3 i,
+.lt-ie9 .h3 i {
+  font-style: normal !important;
+}
+h3 strong,
+.h3 strong,
+h3 b,
+.h3 b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+.lt-ie9 h3 strong,
+.lt-ie9 .h3 strong,
+.lt-ie9 h3 b,
+.lt-ie9 .h3 b {
+  font-weight: normal !important;
+}
+p + h3,
+p + .h3,
+ul + h3,
+ul + .h3,
+ol + h3,
+ol + .h3,
+dl + h3,
+dl + .h3,
+figure + h3,
+figure + .h3,
+img + h3,
+img + .h3,
+table + h3,
+table + .h3,
+blockquote + h3,
+blockquote + .h3,
+h1 + h3,
+h1 + .h3,
+.h1 + h3,
+.h1 + .h3,
+h2 + h3,
+h2 + .h3,
+.h2 + h3,
+.h2 + .h3,
+h4 + h3,
+h4 + .h3,
+.h4 + h3,
+.h4 + .h3,
+h5 + h3,
+h5 + .h3,
+.h5 + h3,
+.h5 + .h3,
+h6 + h3,
+h6 + .h3,
+.h6 + h3,
+.h6 + .h3 {
+  margin-top: 1.36363636em;
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  h3,
+  .h3 {
+    font-family: Arial, Arial, sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    margin-bottom: 0.83333333em;
+    font-size: 1.125em;
+    line-height: 1.25;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+  .lt-ie9 h3,
+  .lt-ie9 .h3 {
+    font-weight: normal !important;
+  }
+}
+h4,
+.h4 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: 500;
+  margin-bottom: 0.83333333em;
+  font-size: 1.125em;
+  line-height: 1.25;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+.lt-ie9 h4,
+.lt-ie9 .h4 {
+  font-weight: normal !important;
+}
+p + h4,
+p + .h4,
+ul + h4,
+ul + .h4,
+ol + h4,
+ol + .h4,
+dl + h4,
+dl + .h4,
+figure + h4,
+figure + .h4,
+img + h4,
+img + .h4,
+table + h4,
+table + .h4,
+blockquote + h4,
+blockquote + .h4,
+h1 + h4,
+h1 + .h4,
+.h1 + h4,
+.h1 + .h4,
+h2 + h4,
+h2 + .h4,
+.h2 + h4,
+.h2 + .h4,
+h3 + h4,
+h3 + .h4,
+.h3 + h4,
+.h3 + .h4,
+h5 + h4,
+h5 + .h4,
+.h5 + h4,
+.h5 + .h4,
+h6 + h4,
+h6 + .h4,
+.h6 + h4,
+.h6 + .h4 {
+  margin-top: 1.66666667em;
+}
+h5,
+.h5 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+.lt-ie9 h5,
+.lt-ie9 .h5 {
+  font-weight: normal !important;
+}
+p + h5,
+p + .h5,
+ul + h5,
+ul + .h5,
+ol + h5,
+ol + .h5,
+dl + h5,
+dl + .h5,
+figure + h5,
+figure + .h5,
+img + h5,
+img + .h5,
+table + h5,
+table + .h5,
+blockquote + h5,
+blockquote + .h5,
+h1 + h5,
+h1 + .h5,
+.h1 + h5,
+.h1 + .h5,
+h2 + h5,
+h2 + .h5,
+.h2 + h5,
+.h2 + .h5,
+h3 + h5,
+h3 + .h5,
+.h3 + h5,
+.h3 + .h5,
+h4 + h5,
+h4 + .h5,
+.h4 + h5,
+.h4 + .h5,
+h6 + h5,
+h6 + .h5,
+.h6 + h5,
+.h6 + .h5 {
+  margin-top: 2.14285714em;
+}
+h6,
+.h6 {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.25em;
+  font-size: 0.75em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+.lt-ie9 h6,
+.lt-ie9 .h6 {
+  font-weight: normal !important;
+}
+p + h6,
+p + .h6,
+ul + h6,
+ul + .h6,
+ol + h6,
+ol + .h6,
+dl + h6,
+dl + .h6,
+figure + h6,
+figure + .h6,
+img + h6,
+img + .h6,
+table + h6,
+table + .h6,
+blockquote + h6,
+blockquote + .h6,
+h1 + h6,
+h1 + .h6,
+.h1 + h6,
+.h1 + .h6,
+h2 + h6,
+h2 + .h6,
+.h2 + h6,
+.h2 + .h6,
+h3 + h6,
+h3 + .h6,
+.h3 + h6,
+.h3 + .h6,
+h4 + h6,
+h4 + .h6,
+.h4 + h6,
+.h4 + .h6,
+h5 + h6,
+h5 + .h6,
+.h5 + h6,
+.h5 + .h6 {
+  margin-top: 2.5em;
+}
+.lead-paragraph,
+.subheader,
+.subheader {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.68181818em;
+  font-size: 1.375em;
+  line-height: 1.25;
+  margin-top: 1.36363636em;
+  margin-bottom: 0.83333333em;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lead-paragraph em,
+.lead-paragraph i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lt-ie9 .lead-paragraph em,
+.lt-ie9 .lead-paragraph i {
+  font-style: normal !important;
+}
+.lead-paragraph strong,
+.lead-paragraph b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+.lt-ie9 .lead-paragraph strong,
+.lt-ie9 .lead-paragraph b {
+  font-weight: normal !important;
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+@media only all and (max-width: 37.5em) {
+  .lead-paragraph,
+  .subheader,
+  .subheader {
+    margin-top: 1.66666667em;
+    font-size: 1.125em;
+  }
+}
+.superheading,
+.superheader,
+.superheader {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  margin-bottom: 0.41666667em;
+  font-size: 3em;
+  line-height: 1.25;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.superheading em,
+.superheading i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.lt-ie9 .superheading em,
+.lt-ie9 .superheading i {
+  font-style: normal !important;
+}
+.superheading strong,
+.superheading b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+.lt-ie9 .superheading strong,
+.lt-ie9 .superheading b {
+  font-weight: normal !important;
+}
+/* topdoc
+  name: Body copy element vertical margins
+  family: cf-core
+  patterns:
+    - name: Consistent vertical margins
+      notes:
+        - Applies 15px bottom margin to all p, ul, ol, dl, figure, table, and blockquote elements.
+        - Applies -5px top margin to lists following paragraphs to reduce margin between them to 10px.
+        - Applies 8px bottom margin to list items that are not within a nav element.
+        - Assumes that the font size of each of these items remains the default.
+      markup: |
+        <p>Paragraph margin example</p>
+        <p>Paragraph margin example</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
+        <p>Paragraph margin example</p>
+  tags:
+    - cf-core
+*/
+p,
+ul,
+ol,
+dl,
+figure,
+table,
+blockquote {
+  margin-top: 0;
+  margin-bottom: 0.9375em;
+}
+p + ul,
+p + ol {
+  margin-top: -0.3125em;
+}
+:not(nav) li {
+  margin-bottom: 0.5em;
+}
+.lt-ie9 nav li {
+  margin-bottom: 0;
+}
+/* topdoc
+  name: Default link
+  notes:
+    - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not
+      be used in production."
+  family: cf-core
+  patterns:
+    - name: Default state
+      markup: |
+        <a href="#">Default link style</a>
+    - name: Visited state
+      markup: |
+        <a href="#" class="visited">Visited link style</a>
+    - name: Hovered state
+      markup: |
+        <a href="#" class="hover">Hovered link style</a>
+    - name: Focused state
+      markup: |
+        <a href="#" class="focus">Focused link style</a>
+    - name: Active state
+      markup: |
+        <a href="#" class="active">Active link style</a>
+  tags:
+    - cf-core
+*/
+a {
+  border-width: 0;
+  border-style: dotted;
+  border-color: #0071bc;
+  color: #0071bc;
+  text-decoration: none;
+}
+a:visited,
+a.visited {
+  border-color: #4c2c92;
+  color: #4c2c92;
+}
+a:hover,
+a.hover {
+  border-style: solid;
+  border-color: #205493;
+  color: #205493;
+}
+a:focus,
+a.focus {
+  border-style: solid;
+  outline: thin dotted;
+}
+a:active,
+a.active {
+  border-style: solid;
+  border-color: #046b99;
+  color: #046b99;
+}
+/* topdoc
+  name: Underlined links
+  family: cf-core
+  patterns:
+    - name: States
+      notes:
+        - "Note that the .visited, .hover, .focus, .active classes are for demonstration purposes only and should not
+          be used in production."
+        - "The underline style properties are mostly set above in the a tag.
+          To enable the underline simply set a bottom-border-width as done here."
+      markup: |
+        <p>
+            <a href="#">Default</a>,
+            <a href="#" class="visited">Visited</a>,
+            <a href="#" class="hover">Hovered</a>,
+            <a href="#" class="focus">Focused</a>,
+            <a href="#" class="active">Active</a>
+        </p>
+    - name: Underline conditions
+      notes:
+        - "We're restricting link borders to links within p, li, and dd so that
+          we don't have to override them every time we want a plain link."
+      markup: |
+        <p>
+            <a href="#">A child of a paragraph</a>
+        </p>
+        <ul>
+            <li>
+                <a href="#">A child of a list item</a>
+            </li>
+        </ul>
+        <dl>
+            <dt>
+                Definition list term
+            </dt>
+            <dd>
+                <a href="#">A child of a definition list description</a>
+            </dd>
+        </dl>
+    - name: Exceptions for underlined links
+      notes:
+        - "Inline text links inside of a nav element are not underlined."
+      markup: |
+        <nav>
+            <p>
+                <a href="#">A child of a paragraph</a>
+            </p>
+            <ul>
+                <li>
+                    <a href="#">A child of a list item</a>
+                </li>
+            </ul>
+            <dl>
+                <dt>
+                    Definition list term
+                </dt>
+                <dd>
+                    <a href="#">A child of a definition list description</a>
+                </dd>
+            </dl>
+        </nav>
+  tags:
+    - cf-core
+*/
+p a,
+li a,
+dd a {
+  border-bottom-width: 1px;
+}
+nav a {
+  border-bottom-width: 0;
+}
+/* topdoc
+  name: Lists
+  family: cf-core
+  patterns:
+    - name: Unordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ul>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ul>
+    - name: Ordered list
+      markup: |
+        <p>Paragraph example for visual reference</p>
+        <ol>
+            <li>List item 1</li>
+            <li>List item 2</li>
+            <li>List item 3</li>
+        </ol>
+  tags:
+    - cf-core
+*/
+ul {
+  padding-left: 2em;
+  list-style: square;
+}
+ol {
+  padding-left: 1.9375em;
+}
+ol > li {
+  padding-left: 0.0625em;
+}
+/* topdoc
+  name: Tables
+  family: cf-core
+  patterns:
+    - name: Standard table
+      markup: |
+        <table>
+            <thead>
+                <tr>
+                    <th>Column 1 header</th>
+                    <th>Column 2 header</th>
+                    <th>Column 3 header</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Row 1, column 1</td>
+                    <td>Row 1, column 2</td>
+                    <td>Row 1, column 3</td>
+                </tr>
+                <tr>
+                    <td>Row 2, column 1</td>
+                    <td>Row 2, column 2</td>
+                    <td>Row 2, column 3</td>
+                </tr>
+                <tr>
+                    <td>Row 3, column 1</td>
+                    <td>Row 3, column 2</td>
+                    <td>Row 3, column 3</td>
+                </tr>
+            </tbody>
+        </table>
+  tags:
+    - cf-core
+*/
+table {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+table em,
+table i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+.lt-ie9 table em,
+.lt-ie9 table i {
+  font-style: normal !important;
+}
+table strong,
+table b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+.lt-ie9 table strong,
+.lt-ie9 table b {
+  font-weight: normal !important;
+}
+th,
+td {
+  padding: 0.625em;
+}
+thead th,
+thead td {
+  color: #212121;
+  background: #f1f1f1;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  margin-bottom: 1.07142857em;
+  font-size: 0.875em;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+.lt-ie9 thead th,
+.lt-ie9 thead td {
+  font-weight: normal !important;
+}
+p + thead th,
+p + thead td,
+ul + thead th,
+ul + thead td,
+ol + thead th,
+ol + thead td,
+dl + thead th,
+dl + thead td,
+figure + thead th,
+figure + thead td,
+img + thead th,
+img + thead td,
+table + thead th,
+table + thead td,
+blockquote + thead th,
+blockquote + thead td,
+h1 + thead th,
+h1 + thead td,
+.h1 + thead th,
+.h1 + thead td,
+h2 + thead th,
+h2 + thead td,
+.h2 + thead th,
+.h2 + thead td,
+h3 + thead th,
+h3 + thead td,
+.h3 + thead th,
+.h3 + thead td,
+h4 + thead th,
+h4 + thead td,
+.h4 + thead th,
+.h4 + thead td,
+h6 + thead th,
+h6 + thead td,
+.h6 + thead th,
+.h6 + thead td {
+  margin-top: 2.14285714em;
+}
+thead,
+tbody tr {
+  border-bottom: 1px solid #5b616b;
+}
+th {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  text-align: left;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
+}
+.lt-ie9 th {
+  font-weight: normal !important;
+}
+tbody th {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+tbody th em,
+tbody th i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+.lt-ie9 tbody th em,
+.lt-ie9 tbody th i {
+  font-style: normal !important;
+}
+tbody th strong,
+tbody th b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+.lt-ie9 tbody th strong,
+.lt-ie9 tbody th b {
+  font-weight: normal !important;
+}
+/* topdoc
+  name: Block quote
+  family: cf-core
+  patterns:
+    - name: Default block quote
+      markup: |
+        <blockquote cite="link-to-source">
+            Lorem ipsum dolor sit amet, consectetur adipisicing elit. Culpa
+            similique fugit hic eligendi praesentium officiis illum optio iusto
+            commodi eum tempore nisi ad in perferendis enim quo dolores.
+            Reprehenderit similique earum quibusdam possimus vitae esse
+            nesciunt mollitia sed beatae aliquid dolores iure a impedit quam
+            minus eum modi illum ducimus eligendi eveniet labore non sequi
+            voluptate et totam praesentium animi itaque asperiores dolorum
+            sunt laudantium repellat nam commodi. Perspiciatis natus aliquam
+            veniam officiis ducimus voluptatum ut necessitatibus non!
+        </blockquote>
+      notes:
+        - "Use a block quote to quote from an external work. See .pull-quote if
+          you need to highlight an excerpt from the current work."
+        - "It is best practice to document the URL of a quoted work using the
+          cite attribute."
+  tags:
+    - cf-core
+*/
+blockquote {
+  margin-right: 0.9375em;
+  margin-left: 0.9375em;
+}
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
+  }
+}
+@media only all and (min-width: 37.5625em) {
+  blockquote {
+    margin-right: 1.875em;
+    margin-left: 1.875em;
+  }
+}
+/* topdoc
+    name: Form labels
+    family: cf-core
+    notes:
+      - "Visit https://github.com/cfpb/cf-forms for advanced form label patterns."
+    patterns:
+    - name: Default label
+      markup: |
+        <label>Form label</label>
+    - name: Label wrapping a radio or checkbox
+      markup: |
+        <label>
+            <input type="radio">
+            Radio label
+        </label>
+        <label>
+            <input type="checkbox">
+            Checkbox label
+        </label>
+    tags:
+    - cf-core
+*/
+label {
+  display: block;
+  margin-bottom: 0.3125em;
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label em,
+label i {
+  font-family: Arial, Arial, sans-serif;
+  font-style: italic;
+  font-weight: normal;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+.lt-ie9 label em,
+.lt-ie9 label i {
+  font-style: normal !important;
+}
+label strong,
+label b {
+  font-family: Arial, Arial, sans-serif;
+  font-style: normal;
+  font-weight: bold;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+.lt-ie9 label strong,
+.lt-ie9 label b {
+  font-weight: normal !important;
+}
+label input[type="radio"],
+label input[type="checkbox"] {
+  margin-right: 0.375em;
+}
+/* topdoc
+    name: Form elements
+    family: cf-core
+    notes:
+      - "The .focus class is only included for documentation demos and should
+         not be used in production."
+      - "Visit https://github.com/cfpb/cf-forms for advanced form field patterns."
+    patterns:
+    - name: type="text"
+      markup: |
+        <input type="text" value="Lorem ipsum">
+        <input class="focus" type="text" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="text" value="">
+    - name: type="search"
+      markup: |
+        <input type="search" value="Lorem ipsum">
+        <input class="focus" type="search" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="search" value="">
+    - name: type="email"
+      markup: |
+        <input type="email" value="Lorem ipsum">
+        <input class="focus" type="email" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="email" value="">
+    - name: type="url"
+      markup: |
+        <input type="url" value="Lorem ipsum">
+        <input class="focus" type="url" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="url" value="">
+    - name: type="tel"
+      markup: |
+        <input type="tel" value="Lorem ipsum">
+        <input class="focus" type="tel" value="Lorem ipsum">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="tel" value="">
+    - name: type="number"
+      markup: |
+        <input type="number" value="1000">
+        <input class="focus" type="number" value="1000">
+        <br><br>
+        <input placeholder="Lorem ipsum" type="number" value="">
+    - name: textarea
+      markup: |
+        <textarea>Lorem ipsum</textarea>
+        <textarea class="focus">Lorem ipsum</textarea>
+    - name: multi-select
+      markup: |
+        <select multiple>
+            <option value="option1">Lorem</option>
+            <option value="option2">Ipsum</option>
+            <option value="option3">Dolor</option>
+            <option value="option4">Sit</option>
+        </select>
+        <select class="focus" multiple>
+            <option value="option1">Lorem</option>
+            <option value="option2">Ipsum</option>
+            <option value="option3">Dolor</option>
+            <option value="option4">Sit</option>
+        </select>
+    tags:
+    - cf-core
+*/
+input[type="text"],
+input[type="search"],
+input[type="email"],
+input[type="url"],
+input[type="tel"],
+input[type="number"],
+textarea,
+select[multiple] {
+  display: inline-block;
+  margin: 0;
+  padding: 0.375em;
+  font-family: Arial, sans-serif;
+  font-size: 1em;
+  background: #ffffff;
+  border: 1px solid #5b616b;
+  border-radius: 0;
+  vertical-align: top;
+  -webkit-appearance: none;
+  -webkit-user-modify: read-write-plaintext-only;
+}
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+input[type="text"]:focus,
+input[type="text"].focus,
+input[type="search"]:focus,
+input[type="search"].focus,
+input[type="email"]:focus,
+input[type="email"].focus,
+input[type="url"]:focus,
+input[type="url"].focus,
+input[type="tel"]:focus,
+input[type="tel"].focus,
+input[type="number"]:focus,
+input[type="number"].focus,
+textarea:focus,
+textarea.focus,
+select[multiple]:focus,
+select[multiple].focus {
+  border: 1px solid #3e94cf;
+  outline: 1px solid #3e94cf;
+  outline-offset: 0;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+::-webkit-input-placeholder {
+  color: grayscale(#c7336e);
+}
+::-moz-placeholder {
+  color: grayscale(#c7336e);
+}
+:-ms-input-placeholder {
+  color: grayscale(#c7336e);
+}
+/* topdoc
+  name: Images
+  family: cf-core
+  patterns:
+    - name: max-width
+      markup: |
+            <img src="http://placekitten.com/800/40" alt="">
+      notes:
+        - "Gives all images a default max-width of 100% of their container."
+  tags:
+    - cf-core
+*/
+img {
+  max-width: 100%;
+}
+/* topdoc
+  name: Figure
+  family: cf-core
+  patterns:
+    - name: figure
+      markup: |
+        <figure>
+            <img src="http://placekitten.com/340/320">
+        </figure>
+    - name: figure.figure__bordered
+      markup: |
+        <figure class="figure__bordered">
+            <img src="http://placekitten.com/340/320">
+        </figure>
+  tags:
+    - cf-core
+*/
+figure {
+  margin-left: 0;
+  margin-right: 0;
+}
+figure img {
+  vertical-align: middle;
+}
+.figure__bordered img {
+  border: 1px solid #d6d7d9;
 }
 /* topdoc
   name: EOF
@@ -2553,8 +7781,8 @@ figure img {
 */
 @font-face {
   font-family: 'CFPB Minicons';
-  src: url('fonts/cf-icons.eot');
-  src: url('fonts/cf-icons.eot?#iefix') format('embedded-opentype'), url('fonts/cf-icons.woff') format('woff'), url('fonts/cf-icons.ttf') format('truetype'), url('fonts/cf-icons.svg') format('svg');
+  src: url('../fonts/cf-icons.eot');
+  src: url('../fonts/cf-icons.eot?#iefix') format('embedded-opentype'), url('../fonts/cf-icons.woff') format('woff'), url('../fonts/cf-icons.ttf') format('truetype'), url('../fonts/cf-icons.svg') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -4443,6 +9671,9 @@ figure img {
 .lt-ie9 .btn {
   font-weight: normal !important;
 }
+.lt-ie9 .btn {
+  font-weight: normal !important;
+}
 .btn,
 .btn:link,
 .btn:visited {
@@ -5032,34 +10263,34 @@ input.btn::-moz-focus-inner {
 */
 .btn__link {
   padding: 0;
-  border-bottom: 1px dotted #c7336e;
+  border-bottom: 1px dotted #0071bc;
   border-radius: 0;
   margin: 0.5em 0;
 }
 .btn__link,
 .btn__link:link,
 .btn__link:visited {
-  border-bottom-color: #cf447c;
+  border-bottom-color: #4c2c92;
   background-color: transparent;
-  color: #cf447c;
+  color: #4c2c92;
 }
 .btn__link:hover,
 .btn__link.hover {
-  border-bottom: 1px solid #9e2958;
+  border-bottom: 1px solid #205493;
   background-color: transparent;
-  color: #9e2958;
+  color: #205493;
 }
 .btn__link:focus,
 .btn__link.focus {
   border-bottom-style: solid;
   background-color: transparent;
-  outline: thin dotted #c7336e;
+  outline: thin dotted #0071bc;
 }
 .btn__link:active,
 .btn__link.active {
-  border-bottom: 1px solid #8a234c;
+  border-bottom: 1px solid #046b99;
   background-color: transparent;
-  color: #8a234c;
+  color: #046b99;
 }
 .lt-ie8 button.btn__link,
 .lt-ie8 input.btn__link {
@@ -5213,13 +10444,21 @@ input.btn::-moz-focus-inner {
   font-family: Arial, Arial, sans-serif;
   font-style: normal;
   font-weight: bold;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  margin-top: 0;
-  margin-bottom: 0.35714286em;
+  margin-bottom: 1.07142857em;
   font-size: 0.875em;
-  line-height: 1.57142857;
+  letter-spacing: 1px;
+  line-height: 1.25;
+  text-transform: uppercase;
   margin-bottom: 0.71428571em;
+}
+.lt-ie9 .form-label-header {
+  font-weight: normal !important;
+}
+.lt-ie9 .form-label-header {
+  font-weight: normal !important;
+}
+.lt-ie9 .form-label-header {
+  font-weight: normal !important;
 }
 .lt-ie9 .form-label-header {
   font-weight: normal !important;
@@ -5253,6 +10492,9 @@ input.btn::-moz-focus-inner {
     - name: Error state
       codenotes:
         - .error
+      notes:
+        - "See the 'Form icons' section below for guidance on adding icons to
+           states."
       markup: |
         <input class="error" type="text" value="Invalid input" title="Test input">
     - name: Warning state
@@ -5502,6 +10744,14 @@ textarea.disabled {
     margin-right: -15px;
   }
 }
+@media only all and (min-width: 30em) {
+  .input-with-btn {
+    display: block;
+    position: relative;
+    margin-left: -15px;
+    margin-right: -15px;
+  }
+}
 .input-with-btn_input {
   margin-bottom: 0.9375em;
 }
@@ -5516,6 +10766,46 @@ textarea.disabled {
     margin-right: -0.25em;
     vertical-align: top;
     width: 75%;
+    border-right-width: 0;
+  }
+  .lt-ie8 .input-with-btn_input {
+    display: inline;
+    margin-right: 0;
+    zoom: 1;
+    behavior: url('../../box-sizing-polyfill/boxsizing.htc');
+  }
+}
+@media only all and (min-width: 30em) {
+  .input-with-btn_input {
+    display: inline-block;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    border: solid transparent;
+    border-width: 0 15px;
+    margin-right: -0.25em;
+    vertical-align: top;
+    width: 75%;
+    border-right-width: 0;
+  }
+  .lt-ie8 .input-with-btn_input {
+    display: inline;
+    margin-right: 0;
+    zoom: 1;
+    behavior: url('../../box-sizing-polyfill/boxsizing.htc');
+  }
+}
+@media only all and (min-width: 60em) {
+  .input-with-btn_input {
+    display: inline-block;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    border: solid transparent;
+    border-width: 0 15px;
+    margin-right: -0.25em;
+    vertical-align: top;
+    width: 83.33333333%;
     border-right-width: 0;
   }
   .lt-ie8 .input-with-btn_input {
@@ -5565,6 +10855,44 @@ textarea.disabled {
     margin-right: -0.25em;
     vertical-align: top;
     width: 25%;
+  }
+  .lt-ie8 .input-with-btn_btn {
+    display: inline;
+    margin-right: 0;
+    zoom: 1;
+    behavior: url('../../box-sizing-polyfill/boxsizing.htc');
+  }
+}
+@media only all and (min-width: 30em) {
+  .input-with-btn_btn {
+    display: inline-block;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    border: solid transparent;
+    border-width: 0 15px;
+    margin-right: -0.25em;
+    vertical-align: top;
+    width: 25%;
+  }
+  .lt-ie8 .input-with-btn_btn {
+    display: inline;
+    margin-right: 0;
+    zoom: 1;
+    behavior: url('../../box-sizing-polyfill/boxsizing.htc');
+  }
+}
+@media only all and (min-width: 60em) {
+  .input-with-btn_btn {
+    display: inline-block;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    border: solid transparent;
+    border-width: 0 15px;
+    margin-right: -0.25em;
+    vertical-align: top;
+    width: 16.66666667%;
   }
   .lt-ie8 .input-with-btn_btn {
     display: inline;
@@ -5670,4 +10998,4 @@ textarea.disabled {
   name: EOF
   eof: true
 */
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1jc3Mvbm9ybWFsaXplLmNzcyIsIi8uLi9ub3JtYWxpemUtbGVnYWN5LWFkZG9uL25vcm1hbGl6ZS1sZWdhY3ktYWRkb24uY3NzIiwiLy4uL2NmLWNvcmUvc3JjL2NmLXV0aWxpdGllcy5sZXNzIiwiLy4uL2NmLWNvcmUvc3JjL2NmLW1lZGlhLXF1ZXJpZXMubGVzcyIsIi8uLi9jZi1jb3JlL3NyYy9jZi1iYXNlLmxlc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtdmFycy5sZXNzIiwiLy4uL2NmLWljb25zL3NyYy9jZi1pY29ucy5sZXNzIiwiLy4uL2NmLWJ1dHRvbnMvc3JjL2NmLWJ1dHRvbnMubGVzcyIsIi9zcmMvY2YtZm9ybXMubGVzcyIsIi8uLi9jZi1ncmlkL3NyYy9jZi1ncmlkLmxlc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7O0FBUUE7RUFDRSx1QkFBQTs7RUFDQSwwQkFBQTs7RUFDQSw4QkFBQTs7Ozs7O0FBT0Y7RUFDRSxTQUFBOzs7Ozs7Ozs7O0FBYUY7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRSxjQUFBOzs7Ozs7QUFRRjtBQUNBO0FBQ0E7QUFDQTtFQUNFLHFCQUFBOztFQUNBLHdCQUFBOzs7Ozs7O0FBUUYsS0FBSyxJQUFJO0VBQ1AsYUFBQTtFQUNBLFNBQUE7Ozs7OztBQVFGO0FBQ0E7RUFDRSxhQUFBOzs7Ozs7O0FBVUY7RUFDRSw2QkFBQTs7Ozs7O0FBUUYsQ0FBQztBQUNELENBQUM7RUFDQyxVQUFBOzs7Ozs7O0FBVUYsSUFBSTtFQUNGLHlCQUFBOzs7OztBQU9GO0FBQ0E7RUFDRSxpQkFBQTs7Ozs7QUFPRjtFQUNFLGtCQUFBOzs7Ozs7QUFRRjtFQUNFLGNBQUE7RUFDQSxnQkFBQTs7Ozs7QUFPRjtFQUNFLGdCQUFBO0VBQ0EsV0FBQTs7Ozs7QUFPRjtFQUNFLGNBQUE7Ozs7O0FBT0Y7QUFDQTtFQUNFLGNBQUE7RUFDQSxjQUFBO0VBQ0Esa0JBQUE7RUFDQSx3QkFBQTs7QUFHRjtFQUNFLFdBQUE7O0FBR0Y7RUFDRSxlQUFBOzs7Ozs7O0FBVUY7RUFDRSxTQUFBOzs7OztBQU9GLEdBQUcsSUFBSTtFQUNMLGdCQUFBOzs7Ozs7O0FBVUY7RUFDRSxnQkFBQTs7Ozs7QUFPRjtFQUNFLHVCQUFBO0VBQ0EsU0FBQTs7Ozs7QUFPRjtFQUNFLGNBQUE7Ozs7O0FBT0Y7QUFDQTtBQUNBO0FBQ0E7RUFDRSxpQ0FBQTtFQUNBLGNBQUE7Ozs7Ozs7Ozs7Ozs7O0FBa0JGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRSxjQUFBOztFQUNBLGFBQUE7O0VBQ0EsU0FBQTs7Ozs7O0FBT0Y7RUFDRSxpQkFBQTs7Ozs7Ozs7QUFVRjtBQUNBO0VBQ0Usb0JBQUE7Ozs7Ozs7OztBQVdGO0FBQ0EsSUFBSyxNQUFLO0FBQ1YsS0FBSztBQUNMLEtBQUs7RUFDSCwwQkFBQTs7RUFDQSxlQUFBOzs7Ozs7QUFPRixNQUFNO0FBQ04sSUFBSyxNQUFLO0VBQ1IsZUFBQTs7Ozs7QUFPRixNQUFNO0FBQ04sS0FBSztFQUNILFNBQUE7RUFDQSxVQUFBOzs7Ozs7QUFRRjtFQUNFLG1CQUFBOzs7Ozs7Ozs7QUFXRixLQUFLO0FBQ0wsS0FBSztFQUNILHNCQUFBOztFQUNBLFVBQUE7Ozs7Ozs7O0FBU0YsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtFQUNsQixZQUFBOzs7Ozs7QUFRRixLQUFLO0VBQ0gsNkJBQUE7O0VBQ0EsdUJBQUE7Ozs7Ozs7O0FBU0YsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtFQUNsQix3QkFBQTs7Ozs7QUFPRjtFQUNFLHlCQUFBO0VBQ0EsYUFBQTtFQUNBLDhCQUFBOzs7Ozs7QUFRRjtFQUNFLFNBQUE7O0VBQ0EsVUFBQTs7Ozs7O0FBT0Y7RUFDRSxjQUFBOzs7Ozs7QUFRRjtFQUNFLGlCQUFBOzs7Ozs7O0FBVUY7RUFDRSx5QkFBQTtFQUNBLGlCQUFBOztBQUdGO0FBQ0E7RUFDRSxVQUFBOzs7Ozs7Ozs7QUM1WkY7QUFDQTtBQUNBO0VBQ0ksZ0JBQUE7RUFDQSxRQUFBOzs7Ozs7Ozs7QUFZSjtFQUNJLGVBQUE7Ozs7OztBQVFKO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDSSx1QkFBQTs7Ozs7Ozs7OztBQWFKO0VBQ0ksZ0JBQUE7O0FBR0o7RUFDSSxnQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0ksaUJBQUE7RUFDQSxhQUFBOztBQUdKO0VBQ0ksY0FBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0ksaUJBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGlCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDSSxnQkFBQTs7Ozs7QUFPSjtBQUNBO0VBQ0ksYUFBQTs7Ozs7QUFPSjtBQUNBO0FBQ0E7QUFDQTtFQUNJLGNBQWMsd0JBQWQ7Ozs7O0FBT0o7RUFDSSxnQkFBQTtFQUNBLHFCQUFBOzs7OztBQU9KO0VBQ0ksWUFBQTs7Ozs7QUFPSixDQUFDO0FBQ0QsQ0FBQztFQUNHLFNBQVMsRUFBVDtFQUNBLGFBQUE7Ozs7Ozs7O0FBV0o7QUFDQTtBQUNBO0FBQ0E7RUFDSSxhQUFBOztBQUdKO0VBQ0ksa0JBQUE7Ozs7O0FBT0o7QUFDQTtBQUNBO0VBQ0ksbUJBQUE7Ozs7O0FBT0osR0FBSTtBQUNKLEdBQUk7RUFDQSxnQkFBQTtFQUNBLHNCQUFBOzs7Ozs7OztBQVdKO0VBQ0ksK0JBQUE7Ozs7Ozs7O0FBV0o7RUFDSSxTQUFBOzs7Ozs7O0FBU0o7RUFDSSxTQUFBOztFQUNBLG1CQUFBOztFQUNBLGtCQUFBOzs7Ozs7QUFPSjtBQUNBO0FBQ0E7QUFDQTtFQUNJLHdCQUFBO0VBQ0EsdUJBQUE7Ozs7OztBQVFKO0FBQ0EsSUFBSyxNQUFLO0FBQ1YsS0FBSztBQUNMLEtBQUs7RUFDRCxrQkFBQTs7Ozs7O0FBUUosS0FBSztBQUNMLEtBQUs7RUFDRCxhQUFBO0VBQ0EsWUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQzlNQSxNQUFPO0VBQ0gsd0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBeUJKLFdBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTs7QUFFSixPQUFRO0VBQ0osT0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTBCUjtFQUNFLGtCQUFBO0VBQ0EsZ0JBQUE7RUFDQSxNQUFNLGFBQU47RUFDQSxXQUFBO0VBQWEsVUFBQTtFQUNiLFlBQUE7RUFBYyxVQUFBO0VBQVksU0FBQTs7Ozs7Ozs7Ozs7Ozs7QUFpQjVCO0VBQ0kscUJBQUE7O0FBQ0EsT0FBUTtFQUVKLGVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBd0JSO0VBQ0ksWUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb0NKO0VBQ0kscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW1ISjtFQUxJLGtCQUFBO0VBQ0Esc0JBQUE7RUFDQSxTQUFBOztBQU9KO0VBQ0ksa0JBQUE7RUFDQSxNQUFBO0VBQ0EsT0FBQTtFQUNBLFdBQUE7RUFDQSxZQUFBOztBQUdKO0VBakJJLGtCQUFBO0VBQ0EsbUJBQUE7RUFDQSxTQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9OSjtFQUFVLHdCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSwwQkFBQTs7QUFDVjtFQUFVLDZCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTBEVjtFQUFhLFdBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLG1CQUFBOztBQUNiO0VBQWEsbUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FDOWZiLHFCQUgwQztFQUcxQztJRHFpQlEsYUFBQTs7O0FBSVI7RUFDSSxhQUFBOztBQzFpQkoscUJBSDBDO0VBRzFDO0lENGlCUSxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW1EUjtFQUhFLGtCQUFBOztBQU9GO0VBUEUsa0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUVyaUJGO0VBQ0ksY0FBQTtFQUNBLHNCQUFzQix3QkFBdEI7RUFDQSxlQUFBO0VBQ0Esa0JBQUE7O0FBR0o7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBeEdJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFFQSxFQUFFO0FBQUYsR0FBRTtBQUFGLEVBQUU7QUFBRixHQUFFO0FBQUYsRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtBQUFGLEVBQUU7QUFBRixHQUFFO0FBQUYsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FBQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0FBY0YsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0FBY0YsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFBRixFQUFFO0FBQUYsR0FBRTtBQUFGLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7QUFBRixFQUFFO0FBQUYsR0FBRTtBQUFGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUFDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47QUEyQkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0FBMkJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUFzRVI7QUFDQTtFQUlJLGFBQUE7RUFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FEakZKLHFCQUgwQztFQUcxQztFQUFBO0lDckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQWdJQSxhQUFBO0lBR0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLHVCQUFBOztFQW5JQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFQUNBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFQUNBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7OztBRERSLHFCQUgwQyx3Q0FBQTtFQUcxQztFQUFBO0lDckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQWlKQSxhQUFBO0lBR0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLHVCQUFBOztFQXBKQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFQUNBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFQUNBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7OztBRERSLHFCQUgwQyx3Q0FBQSx3Q0FBQTtFQUcxQztFQUFBO0lDOEhJLGFBQUE7SUFHQSwyQkFBQTtJQUNBLGtCQUFBO0lBOUlBLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxnQkFBQTtJQThJQSx1QkFBQTs7RUE3SUEsT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7O0FBZ0dSO0FBQ0E7RUFJSSxhQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLHVCQUFBOztBRGxHSixxQkFIMEM7RUFHMUM7RUFBQTtJQ3JDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUFpSkEsYUFBQTtJQUdBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSx1QkFBQTs7RUFwSkEsRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RUFDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUFDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOzs7QUREUixxQkFIMEMsd0NBQUE7RUFHMUM7RUFBQTtJQzhISSxhQUFBO0lBR0EsMkJBQUE7SUFDQSxrQkFBQTtJQTlJQSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsZ0JBQUE7SUE4SUEsdUJBQUE7O0VBN0lBLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7OztBQWlIUjtBQUNBO0VBSUksYUFBQTtFQUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSx1QkFBQTs7QURuSEoscUJBSDBDO0VBRzFDO0VBQUE7SUM4SEksYUFBQTtJQUdBLDJCQUFBO0lBQ0Esa0JBQUE7SUE5SUEscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGdCQUFBO0lBOElBLHVCQUFBOztFQTdJQSxPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOzs7QUFrSVI7QUFDQTtFQUdJLGFBQUE7RUFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBOUlBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTtFQThJQSx1QkFBQTs7QUE3SUEsT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUErSVI7QUFDQTtBQUNBO0FBQ0E7RUE3SUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBOElBLG1CQUFBO0VBQ0EseUJBQUE7O0FBOUlBLE9BQVE7QUFBUixPQUFRO0FBQVIsT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUFnSlI7QUFDQTtFQUdJLGFBQUE7RUFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsdUJBQUE7O0FBR0o7QUFDQTtFQUdJLGFBQUE7RUFHQSwyQkFBQTtFQUNBLGlCQUFBO0VBQ0EsdUJBQUE7O0FBR0o7RUFLSSxhQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQXZOQSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUF1TkEsdUJBQUE7O0FBck5BLFVBQUU7QUFDRixVQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBQUNBLE9BQVEsV0FmTjtBQWVGLE9BQVEsV0FkTjtFQWVFLDZCQUFBOztBQVhKLFVBQUU7QUFDRixVQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUFDQSxPQUFRLFdBNUJOO0FBNEJGLE9BQVEsV0EzQk47RUE0QkUsOEJBQUE7O0FBc0xSO0VBUUksdUJBQUE7RUFDQSxjQUFBO0VBbk1BLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQW1NQSxpQkFBQTs7QUFsTUEsT0FBUTtFQUNKLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7QUFtTlI7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTtFQUVBLHFCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE4Qko7RUFDSSxlQUFBO0VBQ0Esb0JBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7RUFDQSxxQkFBQTs7QUFFQSxDQUFDO0FBQ0QsQ0FBQztFQUNHLHFCQUFBO0VBQ0EsY0FBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxvQkFBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzRVIsQ0FLSTtBQUpKLEVBSUk7QUFISixFQUdJO0VBQ0ksd0JBQUE7O0FBSVIsR0FBSTtFQUVBLHNCQUFBOzs7Ozs7Ozs7Ozs7Ozs7O0FBbUJKO0VBQ0ksa0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzRUo7RUF6ZUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBQUVBLEtBQUU7QUFDRixLQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBQUNBLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQVhKLEtBQUU7QUFDRixLQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUFDQSxPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FBdWNSO0FBQ0E7RUFDSSx3QkFBQTtFQUNBLG1CQUFBOztBQUVBLEtBQU07QUFBTixLQUFNO0VBQ0YsY0FBQTtFQUNBLG1CQUFBOztBQUdKLEtBQU0sS0FBSSxVQUFVLEtBQU07QUFBMUIsS0FBTSxLQUFJLFVBQVUsS0FBTTtFQUN0QixtQkFBQTs7QUFHSixjQUFlO0FBQWYsY0FBZTtFQUNYLHlCQUFBOztBQUlSO0VBOWRJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQThkQSxnQkFBQTs7QUE3ZEEsT0FBUTtFQUNKLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEwZlI7RUFFSSxjQUFBOztBQU1KLHFCQUo0RTtFQUk1RTtJQUhRLG9CQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF5QlI7RUE5akJJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQWlKQSxhQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLHVCQUFBOztBQXBKQSxNQUFFO0FBQ0YsTUFBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFDQSxPQUFRLE9BZk47QUFlRixPQUFRLE9BZE47RUFlRSw2QkFBQTs7QUFYSixNQUFFO0FBQ0YsTUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxPQTVCTjtBQTRCRixPQUFRLE9BM0JOO0VBNEJFLDhCQUFBOztBRERSLHFCQUgwQztFQUcxQztJQzhISSxhQUFBO0lBR0EsMkJBQUE7SUFDQSxrQkFBQTtJQTlJQSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsZ0JBQUE7SUE4SUEsdUJBQUE7O0VBN0lBLE9BQVE7SUFDSiw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTZqQlI7RUFDSSxjQUFBO0VBRUEsdUJBQUE7RUE3bEJBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFFQSxLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QUFDQSxPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBQ0EsT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBQW9qQlIsS0FNSSxNQUFLO0FBTlQsS0FPSSxNQUFLO0VBQ0QscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1RVIsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0w7QUFDQSxNQUFNO0VBR0YscUJBQUE7RUFDQSxTQUFBO0VBQ0EsZ0JBQUE7RUFDQSw4QkFBQTtFQUNBLGNBQUE7RUFDQSxtQkFBQTtFQUNBLHlCQUFBO0VBQ0EsZ0JBQUE7RUFDQSxtQkFBQTtFQUNBLHdCQUFBO0VBQ0EsOENBQUE7O0FBS0o7RUFDSSx3QkFBQTs7QUFLSixLQUFLLGFBQWE7QUFDbEIsS0FBSyxhQUFhO0FBQ2xCLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxjQUFjO0FBQ25CLEtBQUssY0FBYztBQUNuQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtBQUNwQixRQUFRO0FBQ1IsUUFBUTtBQUNSLE1BQU0sVUFBVTtBQUNoQixNQUFNLFVBQVU7RUFDWix5QkFBQTtFQUNBLDBCQUFBO0VBQ0EsaUJBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNHLE9DM3JCNkIsa0JEMnJCN0I7O0FBRUg7RUFDRyxPQzlyQjZCLGtCRDhyQjdCOztBQUVIO0VBQ0csT0Nqc0I2QixrQkRpc0I3Qjs7Ozs7Ozs7Ozs7Ozs7QUFpQkg7RUFDSSxlQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBc0JKO0VBQ0ksY0FBQTtFQUNBLGVBQUE7O0FBRkosTUFJSTtFQUVJLHNCQUFBOztBQUlSLGlCQUFrQjtFQUNkLHlCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUUxdkJKO0VBQ0UsYUFBYSxlQUFiO0VBQ0EsU0FBUyxxQkFBVDtFQUNBLFNBQVMsNkJBQXVDLE9BQU8sMEJBQ2pELHVCQUFpQyxPQUFPLGFBQ3hDLHNCQUFnQyxPQUFPLGlCQUN2QyxzQkFBZ0MsT0FBTyxNQUg3QztFQUlBLG1CQUFBO0VBQ0Esa0JBQUE7O0FBZ0JGO0FBQ0EsQ0FBQztFQUNDLGFBQWEsZUFBYjtFQUNBLHFCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGNBQUE7RUFDQSxtQ0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvUUYsQ0FBQyxPQUFpQjtFQUNoQix1QkFBQTtFQUNBLG1CQUFBO0VBQ0Esb0JBQUE7O0FBR0YsQ0FBQyxPQUFpQjtFQUFPLGNBQUE7O0FBQ3pCLENBQUMsT0FBaUI7RUFBTyxjQUFBOztBQUN6QixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7QUFDekIsQ0FBQyxPQUFpQjtFQUFPLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBNkR6QixDQUFDLE9BQWlCO0VBQ2hCLHlCQUFBO0VBQ0EsNEJBQUE7RUFDQSxtQkFBQTs7QUFHRixDQUFDLE9BQWlCO0VBekNoQixRQUFRLHdEQUFSO0VBQ0EsbUJBQW1CLGFBQW5CO0VBQ0ksZUFBZSxhQUFmO0VBQ0ksV0FBVyxhQUFYOztBQXVDVixDQUFDLE9BQWlCO0VBMUNoQixRQUFRLHdEQUFSO0VBQ0EsbUJBQW1CLGNBQW5CO0VBQ0ksZUFBZSxjQUFmO0VBQ0ksV0FBVyxjQUFYOztBQXdDVixDQUFDLE9BQWlCO0VBM0NoQixRQUFRLHdEQUFSO0VBQ0EsbUJBQW1CLGNBQW5CO0VBQ0ksZUFBZSxjQUFmO0VBQ0ksV0FBVyxjQUFYOztBQTBDVixDQUFDLE9BQWlCO0VBdENoQixRQUFRLGtFQUFSO0VBQ0EsbUJBQW1CLFlBQW5CO0VBQ0ksZUFBZSxZQUFmO0VBQ0ksV0FBVyxZQUFYOztBQW9DVixDQUFDLE9BQWlCO0VBdkNoQixRQUFRLGtFQUFSO0VBQ0EsbUJBQW1CLFlBQW5CO0VBQ0ksZUFBZSxZQUFmO0VBQ0ksV0FBVyxZQUFYOztBQXNDVixLQUFNLEVBQUMsT0FBaUI7QUFDeEIsS0FBTSxFQUFDLE9BQWlCO0FBQ3hCLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7QUFDeEIsS0FBTSxFQUFDLE9BQWlCO0VBQ3RCLFlBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzQkYsQ0FBQyxPQUFpQjtFQUNoQiw2Q0FBQTtFQUNRLHFDQUFBOztBQUdWLENBQUMsT0FBaUI7RUFDaEIsdUNBQXVDLFFBQXZDO0VBQ1EsK0JBQStCLFFBQS9COztBQUdWO0VBQ0U7SUFDRSxtQkFBbUIsWUFBbkI7SUFDUSxXQUFXLFlBQVg7O0VBRVY7SUFDRSxtQkFBbUIsY0FBbkI7SUFDUSxXQUFXLGNBQVg7OztBQUlaO0VBQ0U7SUFDRSxtQkFBbUIsWUFBbkI7SUFDUSxXQUFXLFlBQVg7O0VBRVY7SUFDRSxtQkFBbUIsY0FBbkI7SUFDUSxXQUFXLGNBQVg7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQThDUixDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxmZCw2RUFBQTs7QUF3ZkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2ZmQsNkVBQUE7O0FBNmZBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNWZkLDZFQUFBOztBQWtnQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqZ0JkLDZFQUFBOztBQXVnQkEsQ0FESCxPQUFpQixHQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0Z0JkLDZFQUFBOztBQTRnQkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzZ0JkLDZFQUFBOztBQWloQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoaEJkLDZFQUFBOztBQXNoQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyaEJkLDZFQUFBOztBQTJoQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExaEJkLDZFQUFBOztBQWdpQkEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL2hCZCw2RUFBQTs7QUFxaUJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcGlCZCw2RUFBQTs7QUEwaUJBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXppQmQsNkVBQUE7O0FBK2lCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTlpQmQsNkVBQUE7O0FBb2pCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5qQmQsNkVBQUE7O0FBeWpCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhqQmQsNkVBQUE7O0FBOGpCQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3akJkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBd21CQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZtQmQsNkVBQUE7O0FBNm1CQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVtQmQsNkVBQUE7O0FBa25CQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpuQmQsNkVBQUE7O0FBdW5CQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRuQmQsNkVBQUE7O0FBNG5CQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNuQmQsNkVBQUE7O0FBaW9CQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhvQmQsNkVBQUE7O0FBc29CQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJvQmQsNkVBQUE7O0FBMm9CQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFvQmQsNkVBQUE7O0FBZ3BCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9vQmQsNkVBQUE7O0FBcXBCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBwQmQsNkVBQUE7O0FBMHBCQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXpwQmQsNkVBQUE7O0FBK3BCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTlwQmQsNkVBQUE7O0FBb3FCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5xQmQsNkVBQUE7O0FBeXFCQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhxQmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFtdEJBLENBREgsT0FBaUIsUUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHRCZCw2RUFBQTs7QUF3dEJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdnRCZCw2RUFBQTs7QUE2dEJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXRCZCw2RUFBQTs7QUFrdUJBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWp1QmQsNkVBQUE7O0FBdXVCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXR1QmQsNkVBQUE7O0FBNHVCQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzdUJkLDZFQUFBOztBQWl2QkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFodkJkLDZFQUFBOztBQXN2QkEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFydkJkLDZFQUFBOztBQTJ2QkEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExdkJkLDZFQUFBOztBQWd3QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvdkJkLDZFQUFBOztBQXF3QkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwd0JkLDZFQUFBOztBQTB3QkEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6d0JkLDZFQUFBOztBQSt3QkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5d0JkLDZFQUFBOztBQW94QkEsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnhCZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMHpCQSxDQURILE9BQWlCLElBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp6QmQsNkVBQUE7O0FBK3pCQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl6QmQsNkVBQUE7O0FBbzBCQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW4wQmQsNkVBQUE7O0FBeTBCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXgwQmQsNkVBQUE7O0FBODBCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTcwQmQsNkVBQUE7O0FBbTFCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWwxQmQsNkVBQUE7O0FBdzFCQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXYxQmQsNkVBQUE7O0FBNjFCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTUxQmQsNkVBQUE7O0FBazJCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWoyQmQsNkVBQUE7O0FBdTJCQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0MkJkLDZFQUFBOztBQTQyQkEsQ0FESCxPQUFpQixJQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzMkJkLDZFQUFBOztBQWkzQkEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoM0JkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErNkJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOTZCZCw2RUFBQTs7QUFvN0JBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbjdCZCw2RUFBQTs7QUF5N0JBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeDdCZCw2RUFBQTs7QUE4N0JBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNzdCZCw2RUFBQTs7QUFtOEJBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbDhCZCw2RUFBQTs7QUF3OEJBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdjhCZCw2RUFBQTs7QUE2OEJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNThCZCw2RUFBQTs7QUFrOUJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBajlCZCw2RUFBQTs7QUF1OUJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdDlCZCw2RUFBQTs7QUE0OUJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMzlCZCw2RUFBQTs7QUFpK0JBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaCtCZCw2RUFBQTs7QUFzK0JBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcitCZCw2RUFBQTs7QUEyK0JBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMStCZCw2RUFBQTs7QUFnL0JBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBLytCZCw2RUFBQTs7QUFxL0JBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcC9CZCw2RUFBQTs7QUEwL0JBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBei9CZCw2RUFBQTs7QUErL0JBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOS9CZCw2RUFBQTs7QUFvZ0NBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbmdDZCw2RUFBQTs7QUF5Z0NBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeGdDZCw2RUFBQTs7QUE4Z0NBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN2dDZCw2RUFBQTs7QUFtaENBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbGhDZCw2RUFBQTs7QUF3aENBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZoQ2QsNkVBQUE7O0FBNmhDQSxDQURILE9BQWlCLElBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVoQ2QsNkVBQUE7O0FBa2lDQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWppQ2QsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBZ29DQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9uQ2QsNkVBQUE7O0FBcW9DQSxDQURILE9BQWlCLG1CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwb0NkLDZFQUFBOztBQTBvQ0EsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6b0NkLDZFQUFBOztBQStvQ0EsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOW9DZCw2RUFBQTs7QUFvcENBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnBDZCw2RUFBQTs7QUF5cENBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHBDZCw2RUFBQTs7QUE4cENBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3BDZCw2RUFBQTs7QUFtcUNBLENBREgsT0FBaUIscUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxxQ2QsNkVBQUE7O0FBd3FDQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZxQ2QsNkVBQUE7O0FBNnFDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVxQ2QsNkVBQUE7O0FBa3JDQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqckNkLDZFQUFBOztBQXVyQ0EsQ0FESCxPQUFpQixzQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHJDZCw2RUFBQTs7QUE0ckNBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3JDZCw2RUFBQTs7QUFpc0NBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhzQ2QsNkVBQUE7O0FBc3NDQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJzQ2QsNkVBQUE7O0FBMnNDQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFzQ2QsNkVBQUE7O0FBZ3RDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9zQ2QsNkVBQUE7O0FBcXRDQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwdENkLDZFQUFBOztBQTB0Q0EsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6dENkLDZFQUFBOztBQSt0Q0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5dENkLDZFQUFBOztBQW91Q0EsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFudUNkLDZFQUFBOztBQXl1Q0EsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHVDZCw2RUFBQTs7QUE4dUNBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTd1Q2QsNkVBQUE7O0FBbXZDQSxDQURILE9BQWlCLDBCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsdkNkLDZFQUFBOztBQXd2Q0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2dkNkLDZFQUFBOztBQTZ2Q0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXZDZCw2RUFBQTs7QUFrd0NBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBandDZCw2RUFBQTs7QUF1d0NBLENBREgsT0FBaUIscUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXR3Q2QsNkVBQUE7O0FBNHdDQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTN3Q2QsNkVBQUE7O0FBaXhDQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoeENkLDZFQUFBOztBQXN4Q0EsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyeENkLDZFQUFBOztBQTJ4Q0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExeENkLDZFQUFBOztBQWd5Q0EsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3hDZCw2RUFBQTs7QUFxeUNBLENBREgsT0FBaUIsc0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB5Q2QsNkVBQUE7O0FBMHlDQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp5Q2QsNkVBQUE7O0FBK3lDQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5eUNkLDZFQUFBOztBQW96Q0EsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuekNkLDZFQUFBOztBQXl6Q0EsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHpDZCw2RUFBQTs7QUE4ekNBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3pDZCw2RUFBQTs7QUFtMENBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWwwQ2QsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQWkrQ0EsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoK0NkLDZFQUFBOztBQXMrQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyK0NkLDZFQUFBOztBQTIrQ0EsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExK0NkLDZFQUFBOztBQWcvQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvK0NkLDZFQUFBOztBQXEvQ0EsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwL0NkLDZFQUFBOztBQTAvQ0EsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6L0NkLDZFQUFBOztBQSsvQ0EsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5L0NkLDZFQUFBOztBQW9nREEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuZ0RkLDZFQUFBOztBQXlnREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4Z0RkLDZFQUFBOztBQThnREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3Z0RkLDZFQUFBOztBQW1oREEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsaERkLDZFQUFBOztBQXdoREEsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdmhEZCw2RUFBQTs7QUE2aERBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNWhEZCw2RUFBQTs7QUFraURBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWppRGQsNkVBQUE7O0FBdWlEQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRpRGQsNkVBQUE7O0FBNGlEQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzaURkLDZFQUFBOztBQWlqREEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoakRkLDZFQUFBOztBQXNqREEsQ0FESCxPQUFpQixtQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcmpEZCw2RUFBQTs7QUEyakRBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMWpEZCw2RUFBQTs7QUFna0RBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS9qRGQsNkVBQUE7O0FBcWtEQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBrRGQsNkVBQUE7O0FBMGtEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXprRGQsNkVBQUE7O0FBK2tEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTlrRGQsNkVBQUE7O0FBb2xEQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFubERkLDZFQUFBOztBQXlsREEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4bERkLDZFQUFBOztBQThsREEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3bERkLDZFQUFBOztBQW1tREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsbURkLDZFQUFBOztBQXdtREEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdm1EZCw2RUFBQTs7QUE2bURBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNW1EZCw2RUFBQTs7QUFrbkRBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBam5EZCw2RUFBQTs7QUF1bkRBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdG5EZCw2RUFBQTs7QUE0bkRBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM25EZCw2RUFBQTs7QUFpb0RBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaG9EZCw2RUFBQTs7QUFzb0RBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcm9EZCw2RUFBQTs7QUEyb0RBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMW9EZCw2RUFBQTs7QUFncERBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL29EZCw2RUFBQTs7QUFxcERBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHBEZCw2RUFBQTs7QUEwcERBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenBEZCw2RUFBQTs7QUErcERBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXBEZCw2RUFBQTs7QUFvcURBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnFEZCw2RUFBQTs7QUF5cURBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHFEZCw2RUFBQTs7QUE4cURBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3FEZCw2RUFBQTs7QUFtckRBLENBREgsT0FBaUIsUUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHJEZCw2RUFBQTs7QUF3ckRBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdnJEZCw2RUFBQTs7QUE2ckRBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTVyRGQsNkVBQUE7O0FBa3NEQSxDQURILE9BQWlCLHdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqc0RkLDZFQUFBOztBQXVzREEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0c0RkLDZFQUFBOztBQTRzREEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3NEZCw2RUFBQTs7QUFpdERBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHREZCw2RUFBQTs7QUFzdERBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ0RGQsNkVBQUE7O0FBMnREQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF0RGQsNkVBQUE7O0FBZ3VEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS90RGQsNkVBQUE7O0FBcXVEQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB1RGQsNkVBQUE7O0FBMHVEQSxDQURILE9BQWlCLG1CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6dURkLDZFQUFBOztBQSt1REEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5dURkLDZFQUFBOztBQW92REEsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnZEZCw2RUFBQTs7QUF5dkRBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHZEZCw2RUFBQTs7QUE4dkRBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTd2RGQsNkVBQUE7O0FBbXdEQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWx3RGQsNkVBQUE7O0FBd3dEQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2d0RkLDZFQUFBOztBQTZ3REEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1d0RkLDZFQUFBOztBQWt4REEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqeERkLDZFQUFBOztBQXV4REEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0eERkLDZFQUFBOztBQTR4REEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzeERkLDZFQUFBOztBQWl5REEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoeURkLDZFQUFBOztBQXN5REEsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnlEZCw2RUFBQTs7QUEyeURBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXlEZCw2RUFBQTs7QUFnekRBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS95RGQsNkVBQUE7O0FBcXpEQSxDQURILE9BQWlCLFFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB6RGQsNkVBQUE7O0FBMHpEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp6RGQsNkVBQUE7O0FBK3pEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl6RGQsNkVBQUE7O0FBbzBEQSxDQURILE9BQWlCLHFCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuMERkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUNzRUo7RUFFSSxxQkFBQTtFQUNBLHNCQUFBO0VBQ0Esc0JBQUE7RUFHQSxTQUFBO0VBQ0EscUJBQUE7RUFDQSxTQUFBO0VBRUEsc0JBQUE7RUg5REEscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGdCQUFBO0VHK0RBLGNBQUE7RUFDQSxtQkFBQTtFQUNBLHFCQUFBO0VBRUEsZUFBQTtFQUNBLGlDQUFBO0VBQ0Esd0JBQUE7O0FIcEVBLE9BQVE7RUFDSiw4QkFBQTs7QUdxRUo7QUFDQSxJQUFDO0FBQ0QsSUFBQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTs7QUFHSixJQUFDO0FBQ0QsSUFBQztFQUNHLHlCQUFBOztBQUdKLElBQUM7QUFDRCxJQUFDO0VBQ0cseUJBQUE7RUFDQSwyQkFBQTtFQUdBLG1CQUFBOztBQUdKLElBQUM7QUFDRCxJQUFDO0VBQ0cseUJBQUE7O0FBR0osTUFBTSxJQUFDO0FBQ1AsS0FBSyxJQUFDO0VBR0YsU0FBQTs7QUFHSixJQUFFO0VBQ0Usb0JBQUE7O0FBSVI7RUFLUSxxQ0FBQTs7QUFMUixPQVNJLE9BQU07QUFUVixPQVVJLE1BQUs7RUFDRCxpQkFBQTtFQUNBLGtCQUFBO0VBQ0EscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBdUNKO0FBQ0EsZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTtFQUNBLGNBQUE7O0FBR0osZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTs7QUFHSixlQUFDO0FBQ0QsZUFBQztFQUNHLHlCQUFBO0VBQ0Esc0JBQUE7O0FBR0osZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErRko7QUFDQSxhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTs7QUFHSixhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBOztBQUdKLGFBQUM7QUFDRCxhQUFDO0VBQ0cseUJBQUE7RUFDQSxzQkFBQTs7QUFHSixhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQWtDSjtBQUFBLElBRkE7QUFHQSxjQUFDO0FBQUQsSUFIQSxVQUdDO0FBQ0QsY0FBQztBQUFELElBSkEsVUFJQztBQUNELGNBQUM7QUFBRCxJQUxBLFVBS0M7QUFDRCxjQUFDO0FBQUQsSUFOQSxVQU1DO0FBQ0QsY0FBQztBQUFELElBUEEsVUFPQztBQUNELGNBQUM7QUFBRCxJQVJBLFVBUUM7QUFDRCxjQUFDO0FBQUQsSUFUQSxVQVNDO0FBQ0QsY0FBQztBQUFELElBVkEsVUFVQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTtFQUNBLGVBQUE7RUFDQSxtQkFBQTs7QUFHSixjQUFDO0FBQUQsSUFqQkEsVUFpQkM7QUFDRCxjQUFDO0FBQUQsSUFsQkEsVUFrQkM7RUFDRyxzQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFrQ1I7RUFFSSxrQ0FBQTtFQUdBLGtCQUFBOztBQUVBLFdBQUU7RUFDRSx5QkFBQTs7QUFLUixPQUlJLE9BQU07QUFKVixPQUtJLE1BQUs7RUFDRCx5QkFBQTtFQUNBLDRCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvSFI7RUFDSSx3QkFBQTtFQUNBLCtCQUFBO0VBQ0EsZ0RBQUE7RUFDQSxzQkFBQTs7QUFFQSxlQUFnQjtFQUNaLDJCQUFBO0VBQ0EsNENBQUE7O0FBRUosYUFBYztFQUNWLDJCQUFBO0VBQ0EsNENBQUE7O0FBRUosY0FBZTtBQUNmLElBQUksVUFBVztFQUNYLDJCQUFBO0VBQ0EsNENBQUE7O0FBSVI7RUFDSSx3QkFBQTtFQUNBLGVBQUE7RUFDQSw4QkFBQTtFQUNBLCtDQUFBO0VBQ0Esc0JBQUE7O0FBRUEsZUFBZ0I7RUFDWiwwQkFBQTtFQUNBLDJDQUFBOztBQUVKLGFBQWM7RUFDViwwQkFBQTtFQUNBLDJDQUFBOztBQUVKLGNBQWU7QUFDZixJQUFJLFVBQVc7RUFDWCwwQkFBQTtFQUNBLDJDQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEyQ1I7RUFVUSxnQkFBQTs7QUFOSixhQUFDO0VBQ0csMEJBQUE7RUFDQSw2QkFBQTs7QUFPSixhQUFDO0VBQ0cseUJBQUE7RUFDQSw0QkFBQTs7QUFLSixhQUFDLE1BQU87QUFDUixhQUFDLE1BQU8sZ0JBQUc7QUFDWDtBQUNBLGFBQUU7QUFDRixhQUFDO0FBQ0QsYUFBRSxnQkFBRztFQUNELHNCQUFBOztBQUdKLGFBQUMsTUFBTSxXQUFZLGdCQUFHO0FBQ3RCLGFBQUMsTUFBTSxXQUFZLGdCQUFHLEtBQUs7QUFDM0IsYUFBQztBQUNELGFBQUMsS0FBSztBQUNOLGFBQUMsV0FBWSxnQkFBRztBQUNoQixhQUFDLFdBQVksZ0JBQUcsS0FBSztFQUNqQiwwQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBd0ZKO0FBQ0EscUJBQUM7QUFDRCxxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDO0FBQ0QscUJBQUM7QUFDRCxxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDO0VBQ0cseUJBQUE7O0FBR0oscUJBQUMsZUFBZTtBQUNoQixxQkFBQyxlQUFlO0FBQ2hCLHFCQUFDLGVBQWU7RUFDWix5QkFBQTs7QUFHSixxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDLGFBQWE7QUFDZCxxQkFBQyxhQUFhO0FBQ2QscUJBQUMsYUFBYTtFQUNWLHlCQUFBOztBQUdKLHFCQUFDO0FBQ0QscUJBQUMsY0FBYztBQUNmLHFCQUFDLGNBQWM7QUFDZixxQkFBQyxjQUFjO0FBQ2YscUJBQUM7QUFDRCxxQkFBQyxVQUFVO0FBQ1gscUJBQUMsVUFBVTtBQUNYLHFCQUFDLFVBQVU7RUFDUCx5QkFBQTs7QUFHSixxQkFBQztFQUNHLDBCQUFBO0VBQ0EsMkJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBcUNSO0VBRUksVUFBQTtFQUNBLGlDQUFBO0VBQ0EsZ0JBQUE7RUFHQSxlQUFBOztBQUVBO0FBQ0EsVUFBQztBQUNELFVBQUM7RUFDRyw0QkFBQTtFQUNBLDZCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQUFDO0FBQ0QsVUFBQztFQUNHLGdDQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBQUM7QUFDRCxVQUFDO0VBQ0csMEJBQUE7RUFDQSw2QkFBQTtFQUNBLDRCQUFBOztBQUdKLFVBQUM7QUFDRCxVQUFDO0VBQ0csZ0NBQUE7RUFDQSw2QkFBQTtFQUNBLGNBQUE7O0FBS1IsT0FFSSxPQUFNO0FBRlYsT0FHSSxNQUFLO0VBQ0QsVUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1Q0osVUFGTTtBQUdOLFVBSE0sZUFHTDtBQUNELFVBSk0sZUFJTDtFQUNHLDRCQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBVk0sZUFVTDtBQUNELFVBWE0sZUFXTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQWhCTSxlQWdCTDtBQUNELFVBakJNLGVBaUJMO0VBQ0csc0JBQUE7O0FBR0osVUFyQk0sZUFxQkw7QUFDRCxVQXRCTSxlQXNCTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1Q0osVUFGTTtBQUdOLFVBSE0sYUFHTDtBQUNELFVBSk0sYUFJTDtFQUNHLDRCQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBVk0sYUFVTDtBQUNELFVBWE0sYUFXTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQWhCTSxhQWdCTDtBQUNELFVBakJNLGFBaUJMO0VBQ0csc0JBQUE7O0FBR0osVUFyQk0sYUFxQkw7QUFDRCxVQXRCTSxhQXNCTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUM5OEJSO0VKV0kscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBOElBLG1CQUFBO0VBQ0EseUJBQUE7RUFPQSxhQUFBO0VBR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLHVCQUFBO0VJdEtBLDJCQUFBOztBSllBLE9BQVE7RUFDSiw4QkFBQTs7Ozs7Ozs7Ozs7Ozs7O0FJTUosYUFBQztBQUNELGFBQUM7QUFDRCxhQUFDO0FBQ0QsYUFBQztBQUNELGFBQUM7QUFDRCxhQUFDO0VBQ0cscUJBQUE7RUFDQSxrQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErQ0osS0FSQyxhQVFBO0FBQUQsS0FQQyxlQU9BO0FBQUQsS0FOQyxjQU1BO0FBQUQsS0FMQyxZQUtBO0FBQUQsS0FKQyxZQUlBO0FBQUQsS0FIQyxlQUdBO0FBQUQsTUFGRSxVQUVEO0FBQUQsUUFBQztFQUNHLHlCQUFBO0VBQ0EsMEJBQUE7O0FBRUosS0FaQyxhQVlBO0FBQUQsS0FYQyxlQVdBO0FBQUQsS0FWQyxjQVVBO0FBQUQsS0FUQyxZQVNBO0FBQUQsS0FSQyxZQVFBO0FBQUQsS0FQQyxlQU9BO0FBQUQsTUFORSxVQU1EO0FBQUQsUUFBQztFQUNHLHlCQUFBO0VBQ0EsMEJBQUE7O0FBRUosS0FoQkMsYUFnQkE7QUFBRCxLQWZDLGVBZUE7QUFBRCxLQWRDLGNBY0E7QUFBRCxLQWJDLFlBYUE7QUFBRCxLQVpDLFlBWUE7QUFBRCxLQVhDLGVBV0E7QUFBRCxNQVZFLFVBVUQ7QUFBRCxRQUFDO0VBQ0cseUJBQUE7RUFDQSwwQkFBQTs7QUFFSixLQXBCQyxhQW9CQTtBQUFELEtBbkJDLGVBbUJBO0FBQUQsS0FsQkMsY0FrQkE7QUFBRCxLQWpCQyxZQWlCQTtBQUFELEtBaEJDLFlBZ0JBO0FBQUQsS0FmQyxlQWVBO0FBQUQsTUFkRSxVQWNEO0FBQUQsUUFBQztFQUNHLHlCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb0RSLENBQUM7RUFHRyxrQkFBQTtFQUNBLFVBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBQUdKLE1BQU8sSUFBRztFQUNOLGNBQUE7O0FBR0osUUFBUyxJQUFHO0VBQ1IsY0FBQTs7QUFHSixRQUFTLElBQUc7RUFDUixjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBcUZKLFdBQVk7RUFDUixtQkFBQTs7QUFHSixnQkFBaUI7RUFDYixvQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUxqUEoscUJBSDBDO0VBRzFDO0lNNFFFLGNBQUE7SUFDQSxrQkFBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7OztBRFFFLGVBQUM7RUFDRyx1QkFBQTs7QUx4UlIscUJBSDBDO0VBRzFDLGVLdVJLO0lDak9ILHFCQUFBO0lBQ0EsOEJBQUE7SUFDRywyQkFBQTtJQUNLLHNCQUFBO0lBWVIseUJBQUE7SUFDQSxvQkFBQTtJQUdBLHFCQUFBO0lBRUEsbUJBQUE7SUE4QkUsVUFBQTtJRGtMUSxxQkFBQTs7RUM5TVYsT0FBUSxnQkQwTUw7SUN4TUQsZUFBQTtJQUdBLGVBQUE7SUFHQSxPQUFBO0lBRUEsY0FBYywwQ0FBZDs7O0FOdkZKLHFCQUgwQztFQUcxQyxlS3VSSztJQ2pPSCxxQkFBQTtJQUNBLDhCQUFBO0lBQ0csMkJBQUE7SUFDSyxzQkFBQTtJQVlSLHlCQUFBO0lBQ0Esb0JBQUE7SUFHQSxxQkFBQTtJQUVBLG1CQUFBO0lBOEJFLG1CQUFBO0lEc0xRLHFCQUFBOztFQ2xOVixPQUFRLGdCRDBNTDtJQ3hNRCxlQUFBO0lBR0EsZUFBQTtJQUdBLE9BQUE7SUFFQSxjQUFjLDBDQUFkOzs7QURnTUEsZUFBQyxNQVdHO0VBQ0ksc0JBQUE7RUFDQSxXQUFBOztBQUlSLGVBQUM7RUFDRyx1QkFBQTs7QUx6U1IscUJBSDBDO0VBRzFDLGVLd1NLO0lDbFBILHFCQUFBO0lBQ0EsOEJBQUE7SUFDRywyQkFBQTtJQUNLLHNCQUFBO0lBWVIseUJBQUE7SUFDQSxvQkFBQTtJQUdBLHFCQUFBO0lBRUEsbUJBQUE7SUE4QkUsVUFBQTs7RUE1QkYsT0FBUSxnQkQyTkw7SUN6TkQsZUFBQTtJQUdBLGVBQUE7SUFHQSxPQUFBO0lBRUEsY0FBYywwQ0FBZDs7O0FOdkZKLHFCQUgwQztFQUcxQyxlS3dTSztJQ2xQSCxxQkFBQTtJQUNBLDhCQUFBO0lBQ0csMkJBQUE7SUFDSyxzQkFBQTtJQVlSLHlCQUFBO0lBQ0Esb0JBQUE7SUFHQSxxQkFBQTtJQUVBLG1CQUFBO0lBOEJFLG1CQUFBOztFQTVCRixPQUFRLGdCRDJOTDtJQ3pORCxlQUFBO0lBR0EsZUFBQTtJQUdBLE9BQUE7SUFFQSxjQUFjLDBDQUFkOzs7QURpTkEsZUFBQyxJQVVHO0VBQ0ksc0JBQUE7RUFDQSxXQUFBOztBQVpSLGVBQUMsSUFlRztFQUNJLDBCQUFBO0VBQ0EsMkJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9DWjtFQUVJLGtCQUFBOztBQUZKLGlCQUlJLE1BQUs7QUFKVCxpQkFLSSxNQUFLO0FBTFQsaUJBTUksTUFBSztBQU5ULGlCQU9JLE1BQUs7QUFQVCxpQkFRSSxNQUFLO0FBUlQsaUJBU0ksTUFBSztFQUNELHNCQUFBO0VBQ0EsV0FBQTtFQUNBLHVCQUFBOztBQUVBLGlCQVZKLE1BQUssYUFVQTtBQUFELGlCQVRKLE1BQUssZUFTQTtBQUFELGlCQVJKLE1BQUssY0FRQTtBQUFELGlCQVBKLE1BQUssWUFPQTtBQUFELGlCQU5KLE1BQUssWUFNQTtBQUFELGlCQUxKLE1BQUssZUFLQTtFQUNHLGtCQUFBOztBQWZaLGlCQW1CSTtFTmlDQSxpQ0FBQTtFTS9CSSxrQkFBQTtFQUNBLGVBQUE7RUFDQSxNQUFBOzs7QUFFQSxpQkFOSixLQU1LO0VBQ0csbUJBQUE7O0FBSUosaUJBWEosS0FXSyxNQUFNO0VBQ0gsc0JBQUEifQ== */
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1jc3Mvbm9ybWFsaXplLmNzcyIsIi9zcmMvdmVuZG9yL25vcm1hbGl6ZS1sZWdhY3ktYWRkb24vbm9ybWFsaXplLWxlZ2FjeS1hZGRvbi5jc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtdXRpbGl0aWVzLmxlc3MiLCIvc3JjL3ZlbmRvci9jZi1jb3JlL3NyYy9jZi11dGlsaXRpZXMubGVzcyIsIi8uLi9jZi1jb3JlL3NyYy9jZi1tZWRpYS1xdWVyaWVzLmxlc3MiLCIvc3JjL3ZlbmRvci9jZi1jb3JlL3NyYy9jZi1tZWRpYS1xdWVyaWVzLmxlc3MiLCIvLi4vY2YtY29yZS9zcmMvY2YtYmFzZS5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtY29yZS9zcmMvY2YtYmFzZS5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtY29yZS9zcmMvY2YtdmFycy5sZXNzIiwiL3NyYy92ZW5kb3IvY2YtaWNvbnMvc3JjL2NmLWljb25zLmxlc3MiLCIvLi4vY2YtYnV0dG9ucy9zcmMvY2YtYnV0dG9ucy5sZXNzIiwiL3NyYy9jZi1mb3Jtcy5sZXNzIiwiLy4uL2NmLWdyaWQvc3JjL2NmLWdyaWQubGVzcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOzs7Ozs7QUFRQTtFQUNFLHVCQUFBOztFQUNBLDBCQUFBOztFQUNBLDhCQUFBOzs7Ozs7QUFPRjtFQUNFLFNBQUE7Ozs7Ozs7Ozs7QUFhRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNFLGNBQUE7Ozs7OztBQVFGO0FBQ0E7QUFDQTtBQUNBO0VBQ0UscUJBQUE7O0VBQ0Esd0JBQUE7Ozs7Ozs7QUFRRixLQUFLLElBQUk7RUFDUCxhQUFBO0VBQ0EsU0FBQTs7Ozs7O0FBUUY7QUFDQTtFQUNFLGFBQUE7Ozs7Ozs7QUFVRjtFQUNFLDZCQUFBOzs7Ozs7QUFRRixDQUFDO0FBQ0QsQ0FBQztFQUNDLFVBQUE7Ozs7Ozs7QUFVRixJQUFJO0VBQ0YseUJBQUE7Ozs7O0FBT0Y7QUFDQTtFQUNFLGlCQUFBOzs7OztBQU9GO0VBQ0Usa0JBQUE7Ozs7OztBQVFGO0VBQ0UsY0FBQTtFQUNBLGdCQUFBOzs7OztBQU9GO0VBQ0UsZ0JBQUE7RUFDQSxXQUFBOzs7OztBQU9GO0VBQ0UsY0FBQTs7Ozs7QUFPRjtBQUNBO0VBQ0UsY0FBQTtFQUNBLGNBQUE7RUFDQSxrQkFBQTtFQUNBLHdCQUFBOztBQUdGO0VBQ0UsV0FBQTs7QUFHRjtFQUNFLGVBQUE7Ozs7Ozs7QUFVRjtFQUNFLFNBQUE7Ozs7O0FBT0YsR0FBRyxJQUFJO0VBQ0wsZ0JBQUE7Ozs7Ozs7QUFVRjtFQUNFLGdCQUFBOzs7OztBQU9GO0VBQ0UsdUJBQUE7RUFDQSxTQUFBOzs7OztBQU9GO0VBQ0UsY0FBQTs7Ozs7QUFPRjtBQUNBO0FBQ0E7QUFDQTtFQUNFLGlDQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7QUFrQkY7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNFLGNBQUE7O0VBQ0EsYUFBQTs7RUFDQSxTQUFBOzs7Ozs7QUFPRjtFQUNFLGlCQUFBOzs7Ozs7OztBQVVGO0FBQ0E7RUFDRSxvQkFBQTs7Ozs7Ozs7O0FBV0Y7QUFDQSxJQUFLLE1BQUs7QUFDVixLQUFLO0FBQ0wsS0FBSztFQUNILDBCQUFBOztFQUNBLGVBQUE7Ozs7OztBQU9GLE1BQU07QUFDTixJQUFLLE1BQUs7RUFDUixlQUFBOzs7OztBQU9GLE1BQU07QUFDTixLQUFLO0VBQ0gsU0FBQTtFQUNBLFVBQUE7Ozs7OztBQVFGO0VBQ0UsbUJBQUE7Ozs7Ozs7OztBQVdGLEtBQUs7QUFDTCxLQUFLO0VBQ0gsc0JBQUE7O0VBQ0EsVUFBQTs7Ozs7Ozs7QUFTRixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0VBQ2xCLFlBQUE7Ozs7OztBQVFGLEtBQUs7RUFDSCw2QkFBQTs7RUFDQSx1QkFBQTs7Ozs7Ozs7QUFTRixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0VBQ2xCLHdCQUFBOzs7OztBQU9GO0VBQ0UseUJBQUE7RUFDQSxhQUFBO0VBQ0EsOEJBQUE7Ozs7OztBQVFGO0VBQ0UsU0FBQTs7RUFDQSxVQUFBOzs7Ozs7QUFPRjtFQUNFLGNBQUE7Ozs7OztBQVFGO0VBQ0UsaUJBQUE7Ozs7Ozs7QUFVRjtFQUNFLHlCQUFBO0VBQ0EsaUJBQUE7O0FBR0Y7QUFDQTtFQUNFLFVBQUE7Ozs7Ozs7OztBQzVaRjtBQUNBO0FBQ0E7RUFDSSxnQkFBQTtFQUNBLFFBQUE7Ozs7Ozs7OztBQVlKO0VBQ0ksZUFBQTs7Ozs7O0FBUUo7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNJLHVCQUFBOzs7Ozs7Ozs7O0FBYUo7RUFDSSxnQkFBQTs7QUFHSjtFQUNJLGdCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDSSxpQkFBQTtFQUNBLGFBQUE7O0FBR0o7RUFDSSxjQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDSSxpQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0ksaUJBQUE7RUFDQSxnQkFBQTs7QUFHSjtFQUNJLGdCQUFBOzs7OztBQU9KO0FBQ0E7RUFDSSxhQUFBOzs7OztBQU9KO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksY0FBYyx3QkFBZDs7Ozs7QUFPSjtFQUNJLGdCQUFBO0VBQ0EscUJBQUE7Ozs7O0FBT0o7RUFDSSxZQUFBOzs7OztBQU9KLENBQUM7QUFDRCxDQUFDO0VBQ0csU0FBUyxFQUFUO0VBQ0EsYUFBQTs7Ozs7Ozs7QUFXSjtBQUNBO0FBQ0E7QUFDQTtFQUNJLGFBQUE7O0FBR0o7RUFDSSxrQkFBQTs7Ozs7QUFPSjtBQUNBO0FBQ0E7RUFDSSxtQkFBQTs7Ozs7QUFPSixHQUFJO0FBQ0osR0FBSTtFQUNBLGdCQUFBO0VBQ0Esc0JBQUE7Ozs7Ozs7O0FBV0o7RUFDSSwrQkFBQTs7Ozs7Ozs7QUFXSjtFQUNJLFNBQUE7Ozs7Ozs7QUFTSjtFQUNJLFNBQUE7O0VBQ0EsbUJBQUE7O0VBQ0Esa0JBQUE7Ozs7OztBQU9KO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksd0JBQUE7RUFDQSx1QkFBQTs7Ozs7O0FBUUo7QUFDQSxJQUFLLE1BQUs7QUFDVixLQUFLO0FBQ0wsS0FBSztFQUNELGtCQUFBOzs7Ozs7QUFRSixLQUFLO0FBQ0wsS0FBSztFQUNELGFBQUE7RUFDQSxZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQzlNQSxNQUFPO0VBQ0gsd0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBeUJKLFdBQUM7RUFDRyxTQUFTLEVBQVQ7RUFDQSxjQUFBO0VBQ0EsV0FBQTs7QUFFSixPQUFRO0VBQ0osT0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTBCUjtFQUNFLGtCQUFBO0VBQ0EsVUFBQTtFQUNBLFdBQUE7RUFDQSxTQUFBO0VBQ0EsWUFBQTtFQUNBLFVBQUE7RUFDQSxnQkFBQTtFQUNBLE1BQU0sYUFBTjs7Ozs7Ozs7Ozs7Ozs7QUFpQkY7RUFDSSxxQkFBQTs7QUFDQSxPQUFRO0VBRUosZUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF3QlI7RUFDSSxZQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvQ0o7RUFDSSxxQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbUhKO0VDTEksa0JBQUE7RUFDQSxzQkFBQTtFQUNBLFNBQUE7O0FET0o7RUFDSSxrQkFBQTtFQUNBLE1BQUE7RUFDQSxPQUFBO0VBQ0EsV0FBQTtFQUNBLFlBQUE7O0FBR0o7RUNqQkksa0JBQUE7RUFDQSxtQkFBQTtFQUNBLFNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FEb05KO0VBQVUsd0JBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDBCQUFBOztBQUNWO0VBQVUsNkJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBMERWO0VBQWEsV0FBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsbUJBQUE7O0FBQ2I7RUFBYSxtQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUVqZ0JiLHFCQUgwQztFQUcxQztJRndpQlEsYUFBQTs7O0FHeGlCUixxQkFIMEM7RUFHMUM7SUh3aUJRLGFBQUE7OztBQUlSO0VBQ0ksYUFBQTs7QUU3aUJKLHFCQUgwQztFQUcxQztJRitpQlEsY0FBQTs7O0FHL2lCUixxQkFIMEM7RUFHMUM7SUgraUJRLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBbURSO0VDSEUsa0JBQUE7O0FET0Y7RUNQRSxrQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBR3hpQkY7RUFDSSxjQUFBO0VBQ0Esc0JBQXNCLHdCQUF0QjtFQUNBLGVBQUE7RUFDQSxrQkFBQTs7QUE4REo7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0ksYUFBQTs7QUFHSjtBQUNBO0VDeEtJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXFHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEckdBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRHFJSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0VBQ1Asd0JBQUE7O0FGOUlSLHFCQUgwQztFQUcxQztFQUFBO0lHckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQThHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEOUdBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRG1KQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7O0VBR0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7SUFDQSx3QkFBQTs7O0FEektaLHFCQUgwQztFQUcxQztFQUFBO0lFckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQThHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEOUdBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRG1KQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7O0VBR0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7SUFDQSx3QkFBQTs7O0FBS1o7QUFDQTtFQ3BOSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUE4R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRDlHQSxFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FEbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURpTEosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztFQUNQLHdCQUFBOztBQUdKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0Esd0JBQUE7O0FGdk1SLHFCQUgwQztFQUcxQztFQUFBO0lHckNJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTtJQXVIQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEdkhBLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RURsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRDRNQSxDQUFFO0VBQUYsQ0FBRTtFQUNGLEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILE1BQU87RUFBUCxNQUFPO0VBQ1AsR0FBSTtFQUFKLEdBQUk7RUFDSixLQUFNO0VBQU4sS0FBTTtFQUNOLFVBQVc7RUFBWCxVQUFXO0lBQ1Asd0JBQUE7OztBRHJOWixxQkFIMEM7RUFHMUM7RUFBQTtJRXJDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUF1SEEsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHZIQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUQ0TUEsQ0FBRTtFQUFGLENBQUU7RUFDRixFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxNQUFPO0VBQVAsTUFBTztFQUNQLEdBQUk7RUFBSixHQUFJO0VBQ0osS0FBTTtFQUFOLEtBQU07RUFDTixVQUFXO0VBQVgsVUFBVztJQUNQLHdCQUFBOzs7QUFLWjtBQUNBO0VDaFFJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQXVIQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEdkhBLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QURsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRDZOSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0FBQ1gsRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSx3QkFBQTs7QUZoUFIscUJBSDBDO0VBRzFDO0VBQUE7SUdaSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsZ0JBQUE7SUF1R0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHhHQSxPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VEREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RUNESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOzs7QUZRUixxQkFIMEM7RUFHMUM7RUFBQTtJRVpJLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxnQkFBQTtJQXVHQSwyQkFBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEeEdBLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VDREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RURESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7OztBRGdRUjtBQUNBO0VDclFJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxnQkFBQTtFQXVHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEeEdBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEb1FKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBQUlSO0FBQ0E7RUN0UkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEMUdBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEcVJKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBQUlSO0FBQ0E7RUNoVEkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBa0hBLHFCQUFBO0VBQ0EsaUJBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEckhBLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEK1NKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7QUFDWCxFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLGlCQUFBOztBQUlSO0FBY0E7QUNBQTtFQXpYSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUF1SEEsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VEbVBBLHdCQUFBO0VBQ0EsMkJBQUE7O0FBM1dBLGVBQUU7QUFDRixlQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxnQkRmTjtBQ2VGLE9BQVEsZ0JEZE47RUNlRSw2QkFBQTs7QURYSixlQUFFO0FBQ0YsZUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxnQkQ1Qk47QUM0QkYsT0FBUSxnQkQzQk47RUM0QkUsOEJBQUE7O0FBbENKLGVBQUU7QUFDRixlQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JDZk47QURlRixPQUFRLGdCQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUFYSixlQUFFO0FBQ0YsZUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkM1Qk47QUQ0QkYsT0FBUSxnQkMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FEbENKLGVBQUU7QUFDRixlQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxnQkRmTjtBQ2VGLE9BQVEsZ0JEZE47RUNlRSw2QkFBQTs7QURYSixlQUFFO0FBQ0YsZUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxnQkQ1Qk47QUM0QkYsT0FBUSxnQkQzQk47RUM0QkUsOEJBQUE7O0FBbENKLGVBQUU7QUFDRixlQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsZ0JDZk47QURlRixPQUFRLGdCQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxnQkFmTjtBQWVGLE9BQVEsZ0JBZE47RUFlRSw2QkFBQTs7QUFYSixlQUFFO0FBQ0YsZUFBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxnQkM1Qk47QUQ0QkYsT0FBUSxnQkMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxnQkE1Qk47QUE0QkYsT0FBUSxnQkEzQk47RUE0QkUsOEJBQUE7O0FIRFIscUJBSDBDO0VBRzFDO0VFb1ZBO0VDQUE7SUROUSx3QkFBQTtJQUNBLGtCQUFBOzs7QUQvVVIscUJBSDBDO0VBRzFDO0VDb1ZBO0VDQUE7SUROUSx3QkFBQTtJQUNBLGtCQUFBOzs7QUFTUjtBQVlBO0FDQUE7RUF6WUkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VEaVlBLDJCQUFBO0VBQ0EsY0FBQTtFQUNBLGlCQUFBOztBQWpZQSxhQUFFO0FBQ0YsYUFBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGNBZk47QUFlRixPQUFRLGNBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLGNEZk47QUNlRixPQUFRLGNEZE47RUNlRSw2QkFBQTs7QURYSixhQUFFO0FBQ0YsYUFBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxjQTVCTjtBQTRCRixPQUFRLGNBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsY0Q1Qk47QUM0QkYsT0FBUSxjRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osYUFBRTtBQUNGLGFBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxjQ2ZOO0FEZUYsT0FBUSxjQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxjQWZOO0FBZUYsT0FBUSxjQWROO0VBZUUsNkJBQUE7O0FBWEosYUFBRTtBQUNGLGFBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsY0M1Qk47QUQ0QkYsT0FBUSxjQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLGNBNUJOO0FBNEJGLE9BQVEsY0EzQk47RUE0QkUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRCtYUjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNJLGFBQUE7RUFDQSx1QkFBQTs7QUFHSixDQUFFO0FBQ0YsQ0FBRTtFQUNFLHFCQUFBOztBQUdKLElBQUksS0FBTTtFQUNOLG9CQUFBOztBQUlKLE9BQVEsSUFBSTtFQUNSLGdCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE4Qko7RUFDSSxlQUFBO0VBQ0Esb0JBQUE7RUFDQSxxQkFBQTtFQUNBLGNBQUE7RUFDQSxxQkFBQTs7QUFFQSxDQUFDO0FBQ0QsQ0FBQztFQUNHLHFCQUFBO0VBQ0EsY0FBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOztBQUdKLENBQUM7QUFDRCxDQUFDO0VBQ0csbUJBQUE7RUFDQSxvQkFBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzRVIsQ0FLSTtBQUpKLEVBSUk7QUFISixFQUdJO0VBQ0ksd0JBQUE7O0FBSVIsR0FBSTtFQUVBLHNCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBNEJKO0VBR0ksaUJBQUE7RUFDQSxrQkFBQTs7QUFJSjtFQUNJLHNCQUFBOztBQURKLEVBR0k7RUFDSSxzQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXlDUjtFQzFwQkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtBQUU7QUFDRixLQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTURmTjtBQ2VGLE9BQVEsTURkTjtFQ2VFLDZCQUFBOztBRFhKLEtBQUU7QUFDRixLQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxNRDVCTjtBQzRCRixPQUFRLE1EM0JOO0VDNEJFLDhCQUFBOztBQWxDSixLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZk47QURlRixPQUFRLE1DZE47RURlRSw2QkFBQTs7QUNESixPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzVCTjtBRDRCRixPQUFRLE1DM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUR3bkJSO0FBQ0E7RUFDSSxnQkFBQTs7QUFFQSxLQUFNO0FBQU4sS0FBTTtFQUNGLGNBQUE7RUFDQSxtQkFBQTtFQ2xvQkoscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7O0FEMUdBLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FDREosT0FBUSxNRDZuQkY7QUM3bkJOLE9BQVEsTUQ2bkJGO0VDNW5CRiw4QkFBQTs7QURESixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUQ2bkJGO0FDN25CTixPQUFRLE1ENm5CRjtFQzVuQkYsOEJBQUE7O0FEcVJKLENBQUUsUUF1V0k7QUF2V04sQ0FBRSxRQXVXSTtBQXRXTixFQUFHLFFBc1dHO0FBdFdOLEVBQUcsUUFzV0c7QUFyV04sRUFBRyxRQXFXRztBQXJXTixFQUFHLFFBcVdHO0FBcFdOLEVBQUcsUUFvV0c7QUFwV04sRUFBRyxRQW9XRztBQW5XTixNQUFPLFFBbVdEO0FBbldOLE1BQU8sUUFtV0Q7QUFsV04sR0FBSSxRQWtXRTtBQWxXTixHQUFJLFFBa1dFO0FBaldOLEtBQU0sUUFpV0E7QUFqV04sS0FBTSxRQWlXQTtBQWhXTixVQUFXLFFBZ1dMO0FBaFdOLFVBQVcsUUFnV0w7QUEvVk4sRUFBRyxRQStWRztBQS9WTixFQUFHLFFBK1ZHO0FBOVZOLEdBQUksUUE4VkU7QUE5Vk4sR0FBSSxRQThWRTtBQTdWTixFQUFHLFFBNlZHO0FBN1ZOLEVBQUcsUUE2Vkc7QUE1Vk4sR0FBSSxRQTRWRTtBQTVWTixHQUFJLFFBNFZFO0FBM1ZOLEVBQUcsUUEyVkc7QUEzVk4sRUFBRyxRQTJWRztBQTFWTixHQUFJLFFBMFZFO0FBMVZOLEdBQUksUUEwVkU7QUF6Vk4sRUFBRyxRQXlWRztBQXpWTixFQUFHLFFBeVZHO0FBeFZOLEdBQUksUUF3VkU7QUF4Vk4sR0FBSSxRQXdWRTtBQXZWTixFQUFHLFFBdVZHO0FBdlZOLEVBQUcsUUF1Vkc7QUF0Vk4sR0FBSSxRQXNWRTtBQXRWTixHQUFJLFFBc1ZFO0VBclZGLHdCQUFBOztBQXhTSixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUQ2bkJGO0FDN25CTixPQUFRLE1ENm5CRjtFQzVuQkYsOEJBQUE7O0FEREosT0FBUSxNQTZuQkY7QUE3bkJOLE9BQVEsTUE2bkJGO0VBNW5CRiw4QkFBQTs7QUNESixPQUFRLE1ENm5CRjtBQzduQk4sT0FBUSxNRDZuQkY7RUM1bkJGLDhCQUFBOztBQXFSSixDQUFFLFFEdVdJO0FDdldOLENBQUUsUUR1V0k7QUN0V04sRUFBRyxRRHNXRztBQ3RXTixFQUFHLFFEc1dHO0FDcldOLEVBQUcsUURxV0c7QUNyV04sRUFBRyxRRHFXRztBQ3BXTixFQUFHLFFEb1dHO0FDcFdOLEVBQUcsUURvV0c7QUNuV04sTUFBTyxRRG1XRDtBQ25XTixNQUFPLFFEbVdEO0FDbFdOLEdBQUksUURrV0U7QUNsV04sR0FBSSxRRGtXRTtBQ2pXTixLQUFNLFFEaVdBO0FDaldOLEtBQU0sUURpV0E7QUNoV04sVUFBVyxRRGdXTDtBQ2hXTixVQUFXLFFEZ1dMO0FDL1ZOLEVBQUcsUUQrVkc7QUMvVk4sRUFBRyxRRCtWRztBQzlWTixHQUFJLFFEOFZFO0FDOVZOLEdBQUksUUQ4VkU7QUM3Vk4sRUFBRyxRRDZWRztBQzdWTixFQUFHLFFENlZHO0FDNVZOLEdBQUksUUQ0VkU7QUM1Vk4sR0FBSSxRRDRWRTtBQzNWTixFQUFHLFFEMlZHO0FDM1ZOLEVBQUcsUUQyVkc7QUMxVk4sR0FBSSxRRDBWRTtBQzFWTixHQUFJLFFEMFZFO0FDelZOLEVBQUcsUUR5Vkc7QUN6Vk4sRUFBRyxRRHlWRztBQ3hWTixHQUFJLFFEd1ZFO0FDeFZOLEdBQUksUUR3VkU7QUN2Vk4sRUFBRyxRRHVWRztBQ3ZWTixFQUFHLFFEdVZHO0FDdFZOLEdBQUksUURzVkU7QUN0Vk4sR0FBSSxRRHNWRTtFQ3JWRix3QkFBQTs7QUQ0VlI7QUFDQSxLQUFNO0VBQ0YsZ0NBQUE7O0FBR0o7RUM1b0JJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFRDRvQkEsZ0JBQUE7O0FBM29CQSxPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtFQUNKLDhCQUFBOztBRDZvQlIsS0FBTTtFQ25yQkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtBK3FCRSxHQS9xQkE7QUFDRixLQThxQkUsR0E5cUJBO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFncUJOLEdBL3FCQTtBQWVGLE9BQVEsTUFncUJOLEdBOXFCQTtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTURncUJOLEdBL3FCQTtBQ2VGLE9BQVEsTURncUJOLEdBOXFCQTtFQ2VFLDZCQUFBOztBRFhKLEtBMHFCRSxHQTFxQkE7QUFDRixLQXlxQkUsR0F6cUJBO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BOG9CTixHQTFxQkE7QUE0QkYsT0FBUSxNQThvQk4sR0F6cUJBO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsTUQ4b0JOLEdBMXFCQTtBQzRCRixPQUFRLE1EOG9CTixHQXpxQkE7RUM0QkUsOEJBQUE7O0FBbENKLEtEK3FCRSxHQy9xQkE7QUFDRixLRDhxQkUsR0M5cUJBO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFncUJOLEdDL3FCQTtBRGVGLE9BQVEsTUFncUJOLEdDOXFCQTtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsTURncUJOLEdDL3FCQTtBQWVGLE9BQVEsTURncUJOLEdDOXFCQTtFQWVFLDZCQUFBOztBQVhKLEtEMHFCRSxHQzFxQkE7QUFDRixLRHlxQkUsR0N6cUJBO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BOG9CTixHQzFxQkE7QUQ0QkYsT0FBUSxNQThvQk4sR0N6cUJBO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUQ4b0JOLEdDMXFCQTtBQTRCRixPQUFRLE1EOG9CTixHQ3pxQkE7RUE0QkUsOEJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRDJxQlI7RUFDSSxzQkFBQTtFQUNBLHFCQUFBOztBRnJyQkoscUJBSDBDO0VBRzFDO0lFd3JCUSxxQkFBQTtJQUNBLG9CQUFBOzs7QUR6ckJSLHFCQUgwQztFQUcxQztJQ3dyQlEscUJBQUE7SUFDQSxvQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTRCUjtFQUNJLGNBQUE7RUFFQSx1QkFBQTtFQ3R2QkEscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBREVBLEtBQUU7QUFDRixLQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsTUFmTjtBQWVGLE9BQVEsTUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsTURmTjtBQ2VGLE9BQVEsTURkTjtFQ2VFLDZCQUFBOztBRFhKLEtBQUU7QUFDRixLQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxNRDVCTjtBQzRCRixPQUFRLE1EM0JOO0VDNEJFLDhCQUFBOztBQWxDSixLQUFFO0FBQ0YsS0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZk47QURlRixPQUFRLE1DZE47RURlRSw2QkFBQTs7QUNESixPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUFYSixLQUFFO0FBQ0YsS0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzVCTjtBRDRCRixPQUFRLE1DM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsTUE1Qk47QUE0QkYsT0FBUSxNQTNCTjtFQTRCRSw4QkFBQTs7QUQ2c0JSLEtBTUksTUFBSztBQU5ULEtBT0ksTUFBSztFQUNELHFCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBdUVSLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMO0FBQ0EsTUFBTTtFQUdGLHFCQUFBO0VBQ0EsU0FBQTtFQUNBLGdCQUFBO0VBQ0EsOEJBQUE7RUFDQSxjQUFBO0VBQ0EsbUJBQUE7RUFDQSx5QkFBQTtFQUNBLGdCQUFBO0VBQ0EsbUJBQUE7RUFDQSx3QkFBQTtFQUNBLDhDQUFBOztBQUtKO0VBQ0ksd0JBQUE7O0FBS0osS0FBSyxhQUFhO0FBQ2xCLEtBQUssYUFBYTtBQUNsQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssY0FBYztBQUNuQixLQUFLLGNBQWM7QUFDbkIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssZUFBZTtBQUNwQixLQUFLLGVBQWU7QUFDcEIsUUFBUTtBQUNSLFFBQVE7QUFDUixNQUFNLFVBQVU7QUFDaEIsTUFBTSxVQUFVO0VBQ1oseUJBQUE7RUFDQSwwQkFBQTtFQUNBLGlCQUFBO0VBQ0EsZ0JBQUE7O0FBR0o7RUFDRyxPRWgwQjZCLGtCRmcwQjdCOztBQUVIO0VBQ0csT0VuMEI2QixrQkZtMEI3Qjs7QUFFSDtFQUNHLE9FdDBCNkIsa0JGczBCN0I7Ozs7Ozs7Ozs7Ozs7O0FBaUJIO0VBQ0ksZUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNCSjtFQUNJLGNBQUE7RUFDQSxlQUFBOztBQUZKLE1BSUk7RUFFSSxzQkFBQTs7QUFJUixpQkFBa0I7RUFDZCx5QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBSDE3QkEsTUFBTztFQUNILHdCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXlCSixXQUFDO0VBQ0csU0FBUyxFQUFUO0VBQ0EsY0FBQTtFQUNBLFdBQUE7O0FBRUosT0FBUTtFQUNKLE9BQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEwQlI7RUFDRSxrQkFBQTtFQUNBLFVBQUE7RUFDQSxXQUFBO0VBQ0EsU0FBQTtFQUNBLFlBQUE7RUFDQSxVQUFBO0VBQ0EsZ0JBQUE7RUFDQSxNQUFNLGFBQU47Ozs7Ozs7Ozs7Ozs7O0FBaUJGO0VBQ0kscUJBQUE7O0FBQ0EsT0FBUTtFQUVKLGVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBd0JSO0VBQ0ksWUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBb0NKO0VBQ0kscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW1ISjtFQUxJLGtCQUFBO0VBQ0Esc0JBQUE7RUFDQSxTQUFBOztBQU9KO0VBQ0ksa0JBQUE7RUFDQSxNQUFBO0VBQ0EsT0FBQTtFQUNBLFdBQUE7RUFDQSxZQUFBOztBQUdKO0VBakJJLGtCQUFBO0VBQ0EsbUJBQUE7RUFDQSxTQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9OSjtFQUFVLHdCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSwwQkFBQTs7QUFDVjtFQUFVLDZCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOztBQUNWO0VBQVUsMkJBQUE7O0FBQ1Y7RUFBVSw4QkFBQTs7QUFDVjtFQUFVLDJCQUFBOztBQUNWO0VBQVUsOEJBQUE7O0FBQ1Y7RUFBVSwyQkFBQTs7QUFDVjtFQUFVLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTBEVjtFQUFhLFdBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLFVBQUE7O0FBQ2I7RUFBYSxVQUFBOztBQUNiO0VBQWEsVUFBQTs7QUFDYjtFQUFhLG1CQUFBOztBQUNiO0VBQWEsbUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FDamdCYixxQkFIMEM7RUFHMUM7SUR3aUJRLGFBQUE7OztBRXhpQlIscUJBSDBDO0VBRzFDO0lGd2lCUSxhQUFBOzs7QUFJUjtFQUNJLGFBQUE7O0FDN2lCSixxQkFIMEM7RUFHMUM7SUQraUJRLGNBQUE7OztBRS9pQlIscUJBSDBDO0VBRzFDO0lGK2lCUSxjQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW1EUjtFQUhFLGtCQUFBOztBQU9GO0VBUEUsa0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUl4aUJGO0VBQ0ksY0FBQTtFQUNBLHNCQUFzQix3QkFBdEI7RUFDQSxlQUFBO0VBQ0Esa0JBQUE7O0FBOERKO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNJLGFBQUE7O0FBR0o7QUFDQTtFQXhLSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUFxR0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRHJHQSxFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FEbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUFxSUosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztFQUNQLHdCQUFBOztBSDlJUixxQkFIMEM7RUFHMUM7RUFBQTtJR3JDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUE4R0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRDlHQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUFtSkEsQ0FBRTtFQUFGLENBQUU7RUFDRixFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxNQUFPO0VBQVAsTUFBTztFQUNQLEdBQUk7RUFBSixHQUFJO0VBQ0osS0FBTTtFQUFOLEtBQU07RUFDTixVQUFXO0VBQVgsVUFBVztJQUNQLHdCQUFBOztFQUdKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0lBQ0Esd0JBQUE7OztBRnpLWixxQkFIMEM7RUFHMUM7RUFBQTtJRXJDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUE4R0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRDlHQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUFtSkEsQ0FBRTtFQUFGLENBQUU7RUFDRixFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxNQUFPO0VBQVAsTUFBTztFQUNQLEdBQUk7RUFBSixHQUFJO0VBQ0osS0FBTTtFQUFOLEtBQU07RUFDTixVQUFXO0VBQVgsVUFBVztJQUNQLHdCQUFBOztFQUdKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0VBQ0osRUFBRztFQUFILEVBQUc7RUFDSCxHQUFJO0VBQUosR0FBSTtFQUNKLEVBQUc7RUFBSCxFQUFHO0VBQ0gsR0FBSTtFQUFKLEdBQUk7RUFDSixFQUFHO0VBQUgsRUFBRztFQUNILEdBQUk7RUFBSixHQUFJO0lBQ0Esd0JBQUE7OztBQUtaO0FBQ0E7RUFwTkkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBOEdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QUQ5R0EsRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLEdEZk47QUNlRixPQUFRLElEZk47QUNlRixPQUFRLEdEZE47QUNjRixPQUFRLElEZE47RUNlRSw2QkFBQTs7QURYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsR0Q1Qk47QUM0QkYsT0FBUSxJRDVCTjtBQzRCRixPQUFRLEdEM0JOO0FDMkJGLE9BQVEsSUQzQk47RUM0QkUsOEJBQUE7O0FBbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQ2ZOO0FEZUYsT0FBUSxJQ2ZOO0FEZUYsT0FBUSxHQ2ROO0FEY0YsT0FBUSxJQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FBWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQzVCTjtBRDRCRixPQUFRLElDNUJOO0FENEJGLE9BQVEsR0MzQk47QUQyQkYsT0FBUSxJQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLEdBNUJOO0FBNEJGLE9BQVEsSUE1Qk47QUE0QkYsT0FBUSxHQTNCTjtBQTJCRixPQUFRLElBM0JOO0VBNEJFLDhCQUFBOztBRGxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FBaUxKLENBQUU7QUFBRixDQUFFO0FBQ0YsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsTUFBTztBQUFQLE1BQU87QUFDUCxHQUFJO0FBQUosR0FBSTtBQUNKLEtBQU07QUFBTixLQUFNO0FBQ04sVUFBVztBQUFYLFVBQVc7RUFDUCx3QkFBQTs7QUFHSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtFQUNBLHdCQUFBOztBSHZNUixxQkFIMEM7RUFHMUM7RUFBQTtJR3JDSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7SUF1SEEsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHZIQSxFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VEbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUNXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VDREosT0FBUSxHRGZOO0VDZUYsT0FBUSxJRGZOO0VDZUYsT0FBUSxHRGROO0VDY0YsT0FBUSxJRGROO0lDZUUsNkJBQUE7O0VEWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ3dCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUNESixPQUFRLEdENUJOO0VDNEJGLE9BQVEsSUQ1Qk47RUM0QkYsT0FBUSxHRDNCTjtFQzJCRixPQUFRLElEM0JOO0lDNEJFLDhCQUFBOztFQWxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0NmTjtFRGVGLE9BQVEsSUNmTjtFRGVGLE9BQVEsR0NkTjtFRGNGLE9BQVEsSUNkTjtJRGVFLDZCQUFBOztFQ0RKLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQVhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUF3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0M1Qk47RUQ0QkYsT0FBUSxJQzVCTjtFRDRCRixPQUFRLEdDM0JOO0VEMkJGLE9BQVEsSUMzQk47SUQ0QkUsOEJBQUE7O0VDREosT0FBUSxHQTVCTjtFQTRCRixPQUFRLElBNUJOO0VBNEJGLE9BQVEsR0EzQk47RUEyQkYsT0FBUSxJQTNCTjtJQTRCRSw4QkFBQTs7RUE0TUEsQ0FBRTtFQUFGLENBQUU7RUFDRixFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsRUFBRztFQUFILEVBQUc7RUFDSCxNQUFPO0VBQVAsTUFBTztFQUNQLEdBQUk7RUFBSixHQUFJO0VBQ0osS0FBTTtFQUFOLEtBQU07RUFDTixVQUFXO0VBQVgsVUFBVztJQUNQLHdCQUFBOzs7QUZyTloscUJBSDBDO0VBRzFDO0VBQUE7SUVyQ0kscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBO0lBdUhBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUR2SEEsRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQ1dGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUNESixPQUFRLEdEZk47RUNlRixPQUFRLElEZk47RUNlRixPQUFRLEdEZE47RUNjRixPQUFRLElEZE47SUNlRSw2QkFBQTs7RURYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFQ0RKLE9BQVEsR0Q1Qk47RUM0QkYsT0FBUSxJRDVCTjtFQzRCRixPQUFRLEdEM0JOO0VDMkJGLE9BQVEsSUQzQk47SUM0QkUsOEJBQUE7O0VBbENKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUFXRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsbUJBQUE7O0VEQ0EsT0FBUSxHQ2ZOO0VEZUYsT0FBUSxJQ2ZOO0VEZUYsT0FBUSxHQ2ROO0VEY0YsT0FBUSxJQ2ROO0lEZUUsNkJBQUE7O0VDREosT0FBUSxHQWZOO0VBZUYsT0FBUSxJQWZOO0VBZUYsT0FBUSxHQWROO0VBY0YsT0FBUSxJQWROO0lBZUUsNkJBQUE7O0VBWEosRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQXdCRixxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsaUJBQUE7O0VEQ0EsT0FBUSxHQzVCTjtFRDRCRixPQUFRLElDNUJOO0VENEJGLE9BQVEsR0MzQk47RUQyQkYsT0FBUSxJQzNCTjtJRDRCRSw4QkFBQTs7RUNESixPQUFRLEdBNUJOO0VBNEJGLE9BQVEsSUE1Qk47RUE0QkYsT0FBUSxHQTNCTjtFQTJCRixPQUFRLElBM0JOO0lBNEJFLDhCQUFBOztFRGxDSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lDV0YscUNBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOztFRENBLE9BQVEsR0FmTjtFQWVGLE9BQVEsSUFmTjtFQWVGLE9BQVEsR0FkTjtFQWNGLE9BQVEsSUFkTjtJQWVFLDZCQUFBOztFQ0RKLE9BQVEsR0RmTjtFQ2VGLE9BQVEsSURmTjtFQ2VGLE9BQVEsR0RkTjtFQ2NGLE9BQVEsSURkTjtJQ2VFLDZCQUFBOztFRFhKLEVBQUU7RUFBRixHQUFFO0VBQ0YsRUFBRTtFQUFGLEdBQUU7SUN3QkYscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRENBLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VDREosT0FBUSxHRDVCTjtFQzRCRixPQUFRLElENUJOO0VDNEJGLE9BQVEsR0QzQk47RUMyQkYsT0FBUSxJRDNCTjtJQzRCRSw4QkFBQTs7RUFsQ0osRUFBRTtFQUFGLEdBQUU7RUFDRixFQUFFO0VBQUYsR0FBRTtJQVdGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7RURDQSxPQUFRLEdDZk47RURlRixPQUFRLElDZk47RURlRixPQUFRLEdDZE47RURjRixPQUFRLElDZE47SURlRSw2QkFBQTs7RUNESixPQUFRLEdBZk47RUFlRixPQUFRLElBZk47RUFlRixPQUFRLEdBZE47RUFjRixPQUFRLElBZE47SUFlRSw2QkFBQTs7RUFYSixFQUFFO0VBQUYsR0FBRTtFQUNGLEVBQUU7RUFBRixHQUFFO0lBd0JGLHFDQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RURDQSxPQUFRLEdDNUJOO0VENEJGLE9BQVEsSUM1Qk47RUQ0QkYsT0FBUSxHQzNCTjtFRDJCRixPQUFRLElDM0JOO0lENEJFLDhCQUFBOztFQ0RKLE9BQVEsR0E1Qk47RUE0QkYsT0FBUSxJQTVCTjtFQTRCRixPQUFRLEdBM0JOO0VBMkJGLE9BQVEsSUEzQk47SUE0QkUsOEJBQUE7O0VBNE1BLENBQUU7RUFBRixDQUFFO0VBQ0YsRUFBRztFQUFILEVBQUc7RUFDSCxFQUFHO0VBQUgsRUFBRztFQUNILEVBQUc7RUFBSCxFQUFHO0VBQ0gsTUFBTztFQUFQLE1BQU87RUFDUCxHQUFJO0VBQUosR0FBSTtFQUNKLEtBQU07RUFBTixLQUFNO0VBQ04sVUFBVztFQUFYLFVBQVc7SUFDUCx3QkFBQTs7O0FBS1o7QUFDQTtFQWhRSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUF1SEEsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRHZIQSxFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VDV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsR0RmTjtBQ2VGLE9BQVEsSURmTjtBQ2VGLE9BQVEsR0RkTjtBQ2NGLE9BQVEsSURkTjtFQ2VFLDZCQUFBOztBRFhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FDREosT0FBUSxHRDVCTjtBQzRCRixPQUFRLElENUJOO0FDNEJGLE9BQVEsR0QzQk47QUMyQkYsT0FBUSxJRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLEdDZk47QURlRixPQUFRLElDZk47QURlRixPQUFRLEdDZE47QURjRixPQUFRLElDZE47RURlRSw2QkFBQTs7QUNESixPQUFRLEdBZk47QUFlRixPQUFRLElBZk47QUFlRixPQUFRLEdBZE47QUFjRixPQUFRLElBZE47RUFlRSw2QkFBQTs7QUFYSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLEdDNUJOO0FENEJGLE9BQVEsSUM1Qk47QUQ0QkYsT0FBUSxHQzNCTjtBRDJCRixPQUFRLElDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsR0E1Qk47QUE0QkYsT0FBUSxJQTVCTjtBQTRCRixPQUFRLEdBM0JOO0FBMkJGLE9BQVEsSUEzQk47RUE0QkUsOEJBQUE7O0FEbENKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxHQWZOO0FBZUYsT0FBUSxJQWZOO0FBZUYsT0FBUSxHQWROO0FBY0YsT0FBUSxJQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxHRGZOO0FDZUYsT0FBUSxJRGZOO0FDZUYsT0FBUSxHRGROO0FDY0YsT0FBUSxJRGROO0VDZUUsNkJBQUE7O0FEWEosRUFBRTtBQUFGLEdBQUU7QUFDRixFQUFFO0FBQUYsR0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLEdENUJOO0FDNEJGLE9BQVEsSUQ1Qk47QUM0QkYsT0FBUSxHRDNCTjtBQzJCRixPQUFRLElEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixFQUFFO0FBQUYsR0FBRTtBQUNGLEVBQUU7QUFBRixHQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsR0NmTjtBRGVGLE9BQVEsSUNmTjtBRGVGLE9BQVEsR0NkTjtBRGNGLE9BQVEsSUNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsR0FmTjtBQWVGLE9BQVEsSUFmTjtBQWVGLE9BQVEsR0FkTjtBQWNGLE9BQVEsSUFkTjtFQWVFLDZCQUFBOztBQVhKLEVBQUU7QUFBRixHQUFFO0FBQ0YsRUFBRTtBQUFGLEdBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsR0M1Qk47QUQ0QkYsT0FBUSxJQzVCTjtBRDRCRixPQUFRLEdDM0JOO0FEMkJGLE9BQVEsSUMzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxHQTVCTjtBQTRCRixPQUFRLElBNUJOO0FBNEJGLE9BQVEsR0EzQk47QUEyQkYsT0FBUSxJQTNCTjtFQTRCRSw4QkFBQTs7QUE2TkosQ0FBRTtBQUFGLENBQUU7QUFDRixFQUFHO0FBQUgsRUFBRztBQUNILEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxNQUFPO0FBQVAsTUFBTztBQUNQLEdBQUk7QUFBSixHQUFJO0FBQ0osS0FBTTtBQUFOLEtBQU07QUFDTixVQUFXO0FBQVgsVUFBVztBQUNYLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0VBQ0Esd0JBQUE7O0FIaFBSLHFCQUgwQztFQUcxQztFQUFBO0lHWkkscUNBQUE7SUFDQSxrQkFBQTtJQUNBLGdCQUFBO0lBdUdBLDJCQUFBO0lBQ0Esa0JBQUE7SUFDQSxpQkFBQTs7RUR4R0EsT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RUNESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFRERKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VDREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7O0FGUVIscUJBSDBDO0VBRzFDO0VBQUE7SUVaSSxxQ0FBQTtJQUNBLGtCQUFBO0lBQ0EsZ0JBQUE7SUF1R0EsMkJBQUE7SUFDQSxrQkFBQTtJQUNBLGlCQUFBOztFRHhHQSxPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOztFQ0RKLE9BQVE7RUFBUixPQUFRO0lBQ0osOEJBQUE7O0VEREosT0FBUTtFQUFSLE9BQVE7SUFDSiw4QkFBQTs7RUNESixPQUFRO0VBQVIsT0FBUTtJQUNKLDhCQUFBOzs7QUFnUVI7QUFDQTtFQXJRSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsZ0JBQUE7RUF1R0EsMkJBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRHhHQSxPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQW9RSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0FBQ1gsRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSx3QkFBQTs7QUFJUjtBQUNBO0VBdFJJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQXVHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUFDQSxpQkFBQTtFQUNBLHlCQUFBOztBRDFHQSxPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQXFSSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0FBQ1gsRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSx3QkFBQTs7QUFJUjtBQUNBO0VBaFRJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQWtIQSxxQkFBQTtFQUNBLGlCQUFBO0VBQ0EsbUJBQUE7RUFDQSxpQkFBQTtFQUNBLHlCQUFBOztBRHJIQSxPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7QUFBUixPQUFRO0VBQ0osOEJBQUE7O0FEREosT0FBUTtBQUFSLE9BQVE7RUFDSiw4QkFBQTs7QUNESixPQUFRO0FBQVIsT0FBUTtFQUNKLDhCQUFBOztBQStTSixDQUFFO0FBQUYsQ0FBRTtBQUNGLEVBQUc7QUFBSCxFQUFHO0FBQ0gsRUFBRztBQUFILEVBQUc7QUFDSCxFQUFHO0FBQUgsRUFBRztBQUNILE1BQU87QUFBUCxNQUFPO0FBQ1AsR0FBSTtBQUFKLEdBQUk7QUFDSixLQUFNO0FBQU4sS0FBTTtBQUNOLFVBQVc7QUFBWCxVQUFXO0FBQ1gsRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7QUFDSixFQUFHO0FBQUgsRUFBRztBQUNILEdBQUk7QUFBSixHQUFJO0FBQ0osRUFBRztBQUFILEVBQUc7QUFDSCxHQUFJO0FBQUosR0FBSTtBQUNKLEVBQUc7QUFBSCxFQUFHO0FBQ0gsR0FBSTtBQUFKLEdBQUk7RUFDQSxpQkFBQTs7QUFJUjtBRGNBO0FDQUE7RUF6WEkscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBdUhBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQW1QQSx3QkFBQTtFQUNBLDJCQUFBOztBRDNXQSxlQUFFO0FBQ0YsZUFBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGdCQWZOO0FBZUYsT0FBUSxnQkFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsZ0JEZk47QUNlRixPQUFRLGdCRGROO0VDZUUsNkJBQUE7O0FEWEosZUFBRTtBQUNGLGVBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsZ0JBNUJOO0FBNEJGLE9BQVEsZ0JBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsZ0JENUJOO0FDNEJGLE9BQVEsZ0JEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixlQUFFO0FBQ0YsZUFBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGdCQ2ZOO0FEZUYsT0FBUSxnQkNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FBWEosZUFBRTtBQUNGLGVBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsZ0JDNUJOO0FENEJGLE9BQVEsZ0JDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsZ0JBNUJOO0FBNEJGLE9BQVEsZ0JBM0JOO0VBNEJFLDhCQUFBOztBRGxDSixlQUFFO0FBQ0YsZUFBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGdCQWZOO0FBZUYsT0FBUSxnQkFkTjtFQWVFLDZCQUFBOztBQ0RKLE9BQVEsZ0JEZk47QUNlRixPQUFRLGdCRGROO0VDZUUsNkJBQUE7O0FEWEosZUFBRTtBQUNGLGVBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsZ0JBNUJOO0FBNEJGLE9BQVEsZ0JBM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsZ0JENUJOO0FDNEJGLE9BQVEsZ0JEM0JOO0VDNEJFLDhCQUFBOztBQWxDSixlQUFFO0FBQ0YsZUFBRTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLGdCQ2ZOO0FEZUYsT0FBUSxnQkNkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsZ0JBZk47QUFlRixPQUFRLGdCQWROO0VBZUUsNkJBQUE7O0FBWEosZUFBRTtBQUNGLGVBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsZ0JDNUJOO0FENEJGLE9BQVEsZ0JDM0JOO0VENEJFLDhCQUFBOztBQ0RKLE9BQVEsZ0JBNUJOO0FBNEJGLE9BQVEsZ0JBM0JOO0VBNEJFLDhCQUFBOztBSERSLHFCQUgwQztFQUcxQztFRW9WQTtFQ0FBO0lBTlEsd0JBQUE7SUFDQSxrQkFBQTs7O0FGL1VSLHFCQUgwQztFQUcxQztFQ29WQTtFQ0FBO0lBTlEsd0JBQUE7SUFDQSxrQkFBQTs7O0FBU1I7QURZQTtBQ0FBO0VBellJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQWlZQSwyQkFBQTtFQUNBLGNBQUE7RUFDQSxpQkFBQTs7QURqWUEsYUFBRTtBQUNGLGFBQUU7RUNXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxjQWZOO0FBZUYsT0FBUSxjQWROO0VBZUUsNkJBQUE7O0FDREosT0FBUSxjRGZOO0FDZUYsT0FBUSxjRGROO0VDZUUsNkJBQUE7O0FEWEosYUFBRTtBQUNGLGFBQUU7RUN3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsY0E1Qk47QUE0QkYsT0FBUSxjQTNCTjtFQTRCRSw4QkFBQTs7QUNESixPQUFRLGNENUJOO0FDNEJGLE9BQVEsY0QzQk47RUM0QkUsOEJBQUE7O0FBbENKLGFBQUU7QUFDRixhQUFFO0VBV0YscUNBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBOztBRENBLE9BQVEsY0NmTjtBRGVGLE9BQVEsY0NkTjtFRGVFLDZCQUFBOztBQ0RKLE9BQVEsY0FmTjtBQWVGLE9BQVEsY0FkTjtFQWVFLDZCQUFBOztBQVhKLGFBQUU7QUFDRixhQUFFO0VBd0JGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTs7QURDQSxPQUFRLGNDNUJOO0FENEJGLE9BQVEsY0MzQk47RUQ0QkUsOEJBQUE7O0FDREosT0FBUSxjQTVCTjtBQTRCRixPQUFRLGNBM0JOO0VBNEJFLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErWFI7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDSSxhQUFBO0VBQ0EsdUJBQUE7O0FBR0osQ0FBRTtBQUNGLENBQUU7RUFDRSxxQkFBQTs7QUFHSixJQUFJLEtBQU07RUFDTixvQkFBQTs7QUFJSixPQUFRLElBQUk7RUFDUixnQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBOEJKO0VBQ0ksZUFBQTtFQUNBLG9CQUFBO0VBQ0EscUJBQUE7RUFDQSxjQUFBO0VBQ0EscUJBQUE7O0FBRUEsQ0FBQztBQUNELENBQUM7RUFDRyxxQkFBQTtFQUNBLGNBQUE7O0FBR0osQ0FBQztBQUNELENBQUM7RUFDRyxtQkFBQTtFQUNBLHFCQUFBO0VBQ0EsY0FBQTs7QUFHSixDQUFDO0FBQ0QsQ0FBQztFQUNHLG1CQUFBO0VBQ0Esb0JBQUE7O0FBR0osQ0FBQztBQUNELENBQUM7RUFDRyxtQkFBQTtFQUNBLHFCQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBc0VSLENBS0k7QUFKSixFQUlJO0FBSEosRUFHSTtFQUNJLHdCQUFBOztBQUlSLEdBQUk7RUFFQSxzQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQTRCSjtFQUdJLGlCQUFBO0VBQ0Esa0JBQUE7O0FBSUo7RUFDSSxzQkFBQTs7QUFESixFQUdJO0VBQ0ksc0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF5Q1I7RUExcEJJLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURFQSxLQUFFO0FBQ0YsS0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLE1EZk47QUNlRixPQUFRLE1EZE47RUNlRSw2QkFBQTs7QURYSixLQUFFO0FBQ0YsS0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsTUQ1Qk47QUM0QkYsT0FBUSxNRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osS0FBRTtBQUNGLEtBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQ2ZOO0FEZUYsT0FBUSxNQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxNQWZOO0FBZUYsT0FBUSxNQWROO0VBZUUsNkJBQUE7O0FBWEosS0FBRTtBQUNGLEtBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUM1Qk47QUQ0QkYsT0FBUSxNQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FBd25CUjtBQUNBO0VBQ0ksZ0JBQUE7O0FBRUEsS0FBTTtBQUFOLEtBQU07RUFDRixjQUFBO0VBQ0EsbUJBQUE7RUFsb0JKLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxpQkFBQTtFQXVHQSwyQkFBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7RUFDQSxpQkFBQTtFQUNBLHlCQUFBOztBRDFHQSxPQUFRLE1DNm5CRjtBRDduQk4sT0FBUSxNQzZuQkY7RUQ1bkJGLDhCQUFBOztBQ0RKLE9BQVEsTUE2bkJGO0FBN25CTixPQUFRLE1BNm5CRjtFQTVuQkYsOEJBQUE7O0FEREosT0FBUSxNQzZuQkY7QUQ3bkJOLE9BQVEsTUM2bkJGO0VENW5CRiw4QkFBQTs7QUNESixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBRHFSSixDQUFFLFFDdVdJO0FEdldOLENBQUUsUUN1V0k7QUR0V04sRUFBRyxRQ3NXRztBRHRXTixFQUFHLFFDc1dHO0FEcldOLEVBQUcsUUNxV0c7QURyV04sRUFBRyxRQ3FXRztBRHBXTixFQUFHLFFDb1dHO0FEcFdOLEVBQUcsUUNvV0c7QURuV04sTUFBTyxRQ21XRDtBRG5XTixNQUFPLFFDbVdEO0FEbFdOLEdBQUksUUNrV0U7QURsV04sR0FBSSxRQ2tXRTtBRGpXTixLQUFNLFFDaVdBO0FEaldOLEtBQU0sUUNpV0E7QURoV04sVUFBVyxRQ2dXTDtBRGhXTixVQUFXLFFDZ1dMO0FEL1ZOLEVBQUcsUUMrVkc7QUQvVk4sRUFBRyxRQytWRztBRDlWTixHQUFJLFFDOFZFO0FEOVZOLEdBQUksUUM4VkU7QUQ3Vk4sRUFBRyxRQzZWRztBRDdWTixFQUFHLFFDNlZHO0FENVZOLEdBQUksUUM0VkU7QUQ1Vk4sR0FBSSxRQzRWRTtBRDNWTixFQUFHLFFDMlZHO0FEM1ZOLEVBQUcsUUMyVkc7QUQxVk4sR0FBSSxRQzBWRTtBRDFWTixHQUFJLFFDMFZFO0FEelZOLEVBQUcsUUN5Vkc7QUR6Vk4sRUFBRyxRQ3lWRztBRHhWTixHQUFJLFFDd1ZFO0FEeFZOLEdBQUksUUN3VkU7QUR2Vk4sRUFBRyxRQ3VWRztBRHZWTixFQUFHLFFDdVZHO0FEdFZOLEdBQUksUUNzVkU7QUR0Vk4sR0FBSSxRQ3NWRTtFRHJWRix3QkFBQTs7QUF4U0osT0FBUSxNQzZuQkY7QUQ3bkJOLE9BQVEsTUM2bkJGO0VENW5CRiw4QkFBQTs7QUNESixPQUFRLE1BNm5CRjtBQTduQk4sT0FBUSxNQTZuQkY7RUE1bkJGLDhCQUFBOztBRERKLE9BQVEsTUM2bkJGO0FEN25CTixPQUFRLE1DNm5CRjtFRDVuQkYsOEJBQUE7O0FDREosT0FBUSxNQTZuQkY7QUE3bkJOLE9BQVEsTUE2bkJGO0VBNW5CRiw4QkFBQTs7QUFxUkosQ0FBRSxRQXVXSTtBQXZXTixDQUFFLFFBdVdJO0FBdFdOLEVBQUcsUUFzV0c7QUF0V04sRUFBRyxRQXNXRztBQXJXTixFQUFHLFFBcVdHO0FBcldOLEVBQUcsUUFxV0c7QUFwV04sRUFBRyxRQW9XRztBQXBXTixFQUFHLFFBb1dHO0FBbldOLE1BQU8sUUFtV0Q7QUFuV04sTUFBTyxRQW1XRDtBQWxXTixHQUFJLFFBa1dFO0FBbFdOLEdBQUksUUFrV0U7QUFqV04sS0FBTSxRQWlXQTtBQWpXTixLQUFNLFFBaVdBO0FBaFdOLFVBQVcsUUFnV0w7QUFoV04sVUFBVyxRQWdXTDtBQS9WTixFQUFHLFFBK1ZHO0FBL1ZOLEVBQUcsUUErVkc7QUE5Vk4sR0FBSSxRQThWRTtBQTlWTixHQUFJLFFBOFZFO0FBN1ZOLEVBQUcsUUE2Vkc7QUE3Vk4sRUFBRyxRQTZWRztBQTVWTixHQUFJLFFBNFZFO0FBNVZOLEdBQUksUUE0VkU7QUEzVk4sRUFBRyxRQTJWRztBQTNWTixFQUFHLFFBMlZHO0FBMVZOLEdBQUksUUEwVkU7QUExVk4sR0FBSSxRQTBWRTtBQXpWTixFQUFHLFFBeVZHO0FBelZOLEVBQUcsUUF5Vkc7QUF4Vk4sR0FBSSxRQXdWRTtBQXhWTixHQUFJLFFBd1ZFO0FBdlZOLEVBQUcsUUF1Vkc7QUF2Vk4sRUFBRyxRQXVWRztBQXRWTixHQUFJLFFBc1ZFO0FBdFZOLEdBQUksUUFzVkU7RUFyVkYsd0JBQUE7O0FBNFZSO0FBQ0EsS0FBTTtFQUNGLGdDQUFBOztBQUdKO0VBNW9CSSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7RUE0b0JBLGdCQUFBOztBRDNvQkEsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7RUFDSiw4QkFBQTs7QUE2b0JSLEtBQU07RUFuckJGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURFQSxLQytxQkUsR0QvcUJBO0FBQ0YsS0M4cUJFLEdEOXFCQTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZ3FCTixHRC9xQkE7QUFlRixPQUFRLE1DZ3FCTixHRDlxQkE7RUFlRSw2QkFBQTs7QUNESixPQUFRLE1BZ3FCTixHRC9xQkE7QUNlRixPQUFRLE1BZ3FCTixHRDlxQkE7RUNlRSw2QkFBQTs7QURYSixLQzBxQkUsR0QxcUJBO0FBQ0YsS0N5cUJFLEdEenFCQTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzhvQk4sR0QxcUJBO0FBNEJGLE9BQVEsTUM4b0JOLEdEenFCQTtFQTRCRSw4QkFBQTs7QUNESixPQUFRLE1BOG9CTixHRDFxQkE7QUM0QkYsT0FBUSxNQThvQk4sR0R6cUJBO0VDNEJFLDhCQUFBOztBQWxDSixLQStxQkUsR0EvcUJBO0FBQ0YsS0E4cUJFLEdBOXFCQTtFQVdGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1DZ3FCTixHQS9xQkE7QURlRixPQUFRLE1DZ3FCTixHQTlxQkE7RURlRSw2QkFBQTs7QUNESixPQUFRLE1BZ3FCTixHQS9xQkE7QUFlRixPQUFRLE1BZ3FCTixHQTlxQkE7RUFlRSw2QkFBQTs7QUFYSixLQTBxQkUsR0ExcUJBO0FBQ0YsS0F5cUJFLEdBenFCQTtFQXdCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQzhvQk4sR0ExcUJBO0FENEJGLE9BQVEsTUM4b0JOLEdBenFCQTtFRDRCRSw4QkFBQTs7QUNESixPQUFRLE1BOG9CTixHQTFxQkE7QUE0QkYsT0FBUSxNQThvQk4sR0F6cUJBO0VBNEJFLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEycUJSO0VBQ0ksc0JBQUE7RUFDQSxxQkFBQTs7QUhyckJKLHFCQUgwQztFQUcxQztJR3dyQlEscUJBQUE7SUFDQSxvQkFBQTs7O0FGenJCUixxQkFIMEM7RUFHMUM7SUV3ckJRLHFCQUFBO0lBQ0Esb0JBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE0QlI7RUFDSSxjQUFBO0VBRUEsdUJBQUE7RUF0dkJBLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURFQSxLQUFFO0FBQ0YsS0FBRTtFQ1dGLHFDQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTs7QURDQSxPQUFRLE1BZk47QUFlRixPQUFRLE1BZE47RUFlRSw2QkFBQTs7QUNESixPQUFRLE1EZk47QUNlRixPQUFRLE1EZE47RUNlRSw2QkFBQTs7QURYSixLQUFFO0FBQ0YsS0FBRTtFQ3dCRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FEQ0EsT0FBUSxNQTVCTjtBQTRCRixPQUFRLE1BM0JOO0VBNEJFLDhCQUFBOztBQ0RKLE9BQVEsTUQ1Qk47QUM0QkYsT0FBUSxNRDNCTjtFQzRCRSw4QkFBQTs7QUFsQ0osS0FBRTtBQUNGLEtBQUU7RUFXRixxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsbUJBQUE7O0FEQ0EsT0FBUSxNQ2ZOO0FEZUYsT0FBUSxNQ2ROO0VEZUUsNkJBQUE7O0FDREosT0FBUSxNQWZOO0FBZUYsT0FBUSxNQWROO0VBZUUsNkJBQUE7O0FBWEosS0FBRTtBQUNGLEtBQUU7RUF3QkYscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBOztBRENBLE9BQVEsTUM1Qk47QUQ0QkYsT0FBUSxNQzNCTjtFRDRCRSw4QkFBQTs7QUNESixPQUFRLE1BNUJOO0FBNEJGLE9BQVEsTUEzQk47RUE0QkUsOEJBQUE7O0FBNnNCUixLQU1JLE1BQUs7QUFOVCxLQU9JLE1BQUs7RUFDRCxxQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXVFUixLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTCxLQUFLO0FBQ0wsS0FBSztBQUNMLEtBQUs7QUFDTDtBQUNBLE1BQU07RUFHRixxQkFBQTtFQUNBLFNBQUE7RUFDQSxnQkFBQTtFQUNBLDhCQUFBO0VBQ0EsY0FBQTtFQUNBLG1CQUFBO0VBQ0EseUJBQUE7RUFDQSxnQkFBQTtFQUNBLG1CQUFBO0VBQ0Esd0JBQUE7RUFDQSw4Q0FBQTs7QUFLSjtFQUNJLHdCQUFBOztBQUtKLEtBQUssYUFBYTtBQUNsQixLQUFLLGFBQWE7QUFDbEIsS0FBSyxlQUFlO0FBQ3BCLEtBQUssZUFBZTtBQUNwQixLQUFLLGNBQWM7QUFDbkIsS0FBSyxjQUFjO0FBQ25CLEtBQUssWUFBWTtBQUNqQixLQUFLLFlBQVk7QUFDakIsS0FBSyxZQUFZO0FBQ2pCLEtBQUssWUFBWTtBQUNqQixLQUFLLGVBQWU7QUFDcEIsS0FBSyxlQUFlO0FBQ3BCLFFBQVE7QUFDUixRQUFRO0FBQ1IsTUFBTSxVQUFVO0FBQ2hCLE1BQU0sVUFBVTtFQUNaLHlCQUFBO0VBQ0EsMEJBQUE7RUFDQSxpQkFBQTtFQUNBLGdCQUFBOztBQUdKO0VBQ0csT0NoMEI2QixrQkRnMEI3Qjs7QUFFSDtFQUNHLE9DbjBCNkIsa0JEbTBCN0I7O0FBRUg7RUFDRyxPQ3QwQjZCLGtCRHMwQjdCOzs7Ozs7Ozs7Ozs7OztBQWlCSDtFQUNJLGVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFzQko7RUFDSSxjQUFBO0VBQ0EsZUFBQTs7QUFGSixNQUlJO0VBRUksc0JBQUE7O0FBSVIsaUJBQWtCO0VBQ2QseUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBRW41Qko7RUFDRSxhQUFhLGVBQWI7RUFDQSxTQUFTLHdCQUFUO0VBQ0EsU0FBUyxnQ0FBdUMsT0FBTywwQkFDakQsMEJBQWlDLE9BQU8sYUFDeEMseUJBQWdDLE9BQU8saUJBQ3ZDLHlCQUFnQyxPQUFPLE1BSDdDO0VBSUEsbUJBQUE7RUFDQSxrQkFBQTs7QUFnQkY7QUFDQSxDQUFDO0VBQ0MsYUFBYSxlQUFiO0VBQ0EscUJBQUE7RUFDQSxrQkFBQTtFQUNBLG1CQUFBO0VBQ0EsY0FBQTtFQUNBLG1DQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW9RRixDQUFDLE9BQWlCO0VBQ2hCLHVCQUFBO0VBQ0EsbUJBQUE7RUFDQSxvQkFBQTs7QUFHRixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7QUFDekIsQ0FBQyxPQUFpQjtFQUFPLGNBQUE7O0FBQ3pCLENBQUMsT0FBaUI7RUFBTyxjQUFBOztBQUN6QixDQUFDLE9BQWlCO0VBQU8sY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUE2RHpCLENBQUMsT0FBaUI7RUFDaEIseUJBQUE7RUFDQSw0QkFBQTtFQUNBLG1CQUFBOztBQUdGLENBQUMsT0FBaUI7RUF6Q2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsYUFBbkI7RUFDSSxlQUFlLGFBQWY7RUFDSSxXQUFXLGFBQVg7O0FBdUNWLENBQUMsT0FBaUI7RUExQ2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsY0FBbkI7RUFDSSxlQUFlLGNBQWY7RUFDSSxXQUFXLGNBQVg7O0FBd0NWLENBQUMsT0FBaUI7RUEzQ2hCLFFBQVEsd0RBQVI7RUFDQSxtQkFBbUIsY0FBbkI7RUFDSSxlQUFlLGNBQWY7RUFDSSxXQUFXLGNBQVg7O0FBMENWLENBQUMsT0FBaUI7RUF0Q2hCLFFBQVEsa0VBQVI7RUFDQSxtQkFBbUIsWUFBbkI7RUFDSSxlQUFlLFlBQWY7RUFDSSxXQUFXLFlBQVg7O0FBb0NWLENBQUMsT0FBaUI7RUF2Q2hCLFFBQVEsa0VBQVI7RUFDQSxtQkFBbUIsWUFBbkI7RUFDSSxlQUFlLFlBQWY7RUFDSSxXQUFXLFlBQVg7O0FBc0NWLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7QUFDeEIsS0FBTSxFQUFDLE9BQWlCO0FBQ3hCLEtBQU0sRUFBQyxPQUFpQjtBQUN4QixLQUFNLEVBQUMsT0FBaUI7RUFDdEIsWUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQXNCRixDQUFDLE9BQWlCO0VBQ2hCLDZDQUFBO0VBQ1EscUNBQUE7O0FBR1YsQ0FBQyxPQUFpQjtFQUNoQix1Q0FBdUMsUUFBdkM7RUFDUSwrQkFBK0IsUUFBL0I7O0FBR1Y7RUFDRTtJQUNFLG1CQUFtQixZQUFuQjtJQUNRLFdBQVcsWUFBWDs7RUFFVjtJQUNFLG1CQUFtQixjQUFuQjtJQUNRLFdBQVcsY0FBWDs7O0FBSVo7RUFDRTtJQUNFLG1CQUFtQixZQUFuQjtJQUNRLFdBQVcsWUFBWDs7RUFFVjtJQUNFLG1CQUFtQixjQUFuQjtJQUNRLFdBQVcsY0FBWDs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBOENSLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbGZkLDZFQUFBOztBQXdmQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZmZCw2RUFBQTs7QUE2ZkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1ZmQsNkVBQUE7O0FBa2dCQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpnQmQsNkVBQUE7O0FBdWdCQSxDQURILE9BQWlCLEdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRnQmQsNkVBQUE7O0FBNGdCQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNnQmQsNkVBQUE7O0FBaWhCQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhoQmQsNkVBQUE7O0FBc2hCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJoQmQsNkVBQUE7O0FBMmhCQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTFoQmQsNkVBQUE7O0FBZ2lCQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvaEJkLDZFQUFBOztBQXFpQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwaUJkLDZFQUFBOztBQTBpQkEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBemlCZCw2RUFBQTs7QUEraUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOWlCZCw2RUFBQTs7QUFvakJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbmpCZCw2RUFBQTs7QUF5akJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeGpCZCw2RUFBQTs7QUE4akJBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdqQmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF3bUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdm1CZCw2RUFBQTs7QUE2bUJBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNW1CZCw2RUFBQTs7QUFrbkJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBam5CZCw2RUFBQTs7QUF1bkJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdG5CZCw2RUFBQTs7QUE0bkJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM25CZCw2RUFBQTs7QUFpb0JBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaG9CZCw2RUFBQTs7QUFzb0JBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcm9CZCw2RUFBQTs7QUEyb0JBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMW9CZCw2RUFBQTs7QUFncEJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL29CZCw2RUFBQTs7QUFxcEJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHBCZCw2RUFBQTs7QUEwcEJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenBCZCw2RUFBQTs7QUErcEJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXBCZCw2RUFBQTs7QUFvcUJBLENBREgsT0FBaUIsT0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbnFCZCw2RUFBQTs7QUF5cUJBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeHFCZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQW10QkEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsdEJkLDZFQUFBOztBQXd0QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2dEJkLDZFQUFBOztBQTZ0QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1dEJkLDZFQUFBOztBQWt1QkEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBanVCZCw2RUFBQTs7QUF1dUJBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHVCZCw2RUFBQTs7QUE0dUJBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTN1QmQsNkVBQUE7O0FBaXZCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh2QmQsNkVBQUE7O0FBc3ZCQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ2QmQsNkVBQUE7O0FBMnZCQSxDQURILE9BQWlCLFFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF2QmQsNkVBQUE7O0FBZ3dCQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS92QmQsNkVBQUE7O0FBcXdCQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB3QmQsNkVBQUE7O0FBMHdCQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp3QmQsNkVBQUE7O0FBK3dCQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl3QmQsNkVBQUE7O0FBb3hCQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFueEJkLDZFQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEwekJBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenpCZCw2RUFBQTs7QUErekJBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXpCZCw2RUFBQTs7QUFvMEJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbjBCZCw2RUFBQTs7QUF5MEJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBeDBCZCw2RUFBQTs7QUE4MEJBLENBREgsT0FBaUIsS0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNzBCZCw2RUFBQTs7QUFtMUJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbDFCZCw2RUFBQTs7QUF3MUJBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdjFCZCw2RUFBQTs7QUE2MUJBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNTFCZCw2RUFBQTs7QUFrMkJBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBajJCZCw2RUFBQTs7QUF1MkJBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXQyQmQsNkVBQUE7O0FBNDJCQSxDQURILE9BQWlCLElBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTMyQmQsNkVBQUE7O0FBaTNCQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWgzQmQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQSs2QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5NkJkLDZFQUFBOztBQW83QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuN0JkLDZFQUFBOztBQXk3QkEsQ0FESCxPQUFpQixJQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4N0JkLDZFQUFBOztBQTg3QkEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3N0JkLDZFQUFBOztBQW04QkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsOEJkLDZFQUFBOztBQXc4QkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2OEJkLDZFQUFBOztBQTY4QkEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1OEJkLDZFQUFBOztBQWs5QkEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqOUJkLDZFQUFBOztBQXU5QkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0OUJkLDZFQUFBOztBQTQ5QkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzOUJkLDZFQUFBOztBQWkrQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFoK0JkLDZFQUFBOztBQXMrQkEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyK0JkLDZFQUFBOztBQTIrQkEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExK0JkLDZFQUFBOztBQWcvQkEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvK0JkLDZFQUFBOztBQXEvQkEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwL0JkLDZFQUFBOztBQTAvQkEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6L0JkLDZFQUFBOztBQSsvQkEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5L0JkLDZFQUFBOztBQW9nQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFuZ0NkLDZFQUFBOztBQXlnQ0EsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4Z0NkLDZFQUFBOztBQThnQ0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3Z0NkLDZFQUFBOztBQW1oQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsaENkLDZFQUFBOztBQXdoQ0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdmhDZCw2RUFBQTs7QUE2aENBLENBREgsT0FBaUIsSUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNWhDZCw2RUFBQTs7QUFraUNBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBamlDZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFnb0NBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL25DZCw2RUFBQTs7QUFxb0NBLENBREgsT0FBaUIsbUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXBvQ2QsNkVBQUE7O0FBMG9DQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXpvQ2QsNkVBQUE7O0FBK29DQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5b0NkLDZFQUFBOztBQW9wQ0EsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFucENkLDZFQUFBOztBQXlwQ0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4cENkLDZFQUFBOztBQThwQ0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3cENkLDZFQUFBOztBQW1xQ0EsQ0FESCxPQUFpQixxQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHFDZCw2RUFBQTs7QUF3cUNBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdnFDZCw2RUFBQTs7QUE2cUNBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXFDZCw2RUFBQTs7QUFrckNBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpyQ2QsNkVBQUE7O0FBdXJDQSxDQURILE9BQWlCLHNCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0ckNkLDZFQUFBOztBQTRyQ0EsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzckNkLDZFQUFBOztBQWlzQ0EsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBaHNDZCw2RUFBQTs7QUFzc0NBLENBREgsT0FBaUIsTUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnNDZCw2RUFBQTs7QUEyc0NBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXNDZCw2RUFBQTs7QUFndENBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3NDZCw2RUFBQTs7QUFxdENBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXB0Q2QsNkVBQUE7O0FBMHRDQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp0Q2QsNkVBQUE7O0FBK3RDQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl0Q2QsNkVBQUE7O0FBb3VDQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW51Q2QsNkVBQUE7O0FBeXVDQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4dUNkLDZFQUFBOztBQTh1Q0EsQ0FESCxPQUFpQixvQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3VDZCw2RUFBQTs7QUFtdkNBLENBREgsT0FBaUIsMEJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWx2Q2QsNkVBQUE7O0FBd3ZDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZ2Q2QsNkVBQUE7O0FBNnZDQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1dkNkLDZFQUFBOztBQWt3Q0EsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqd0NkLDZFQUFBOztBQXV3Q0EsQ0FESCxPQUFpQixxQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdHdDZCw2RUFBQTs7QUE0d0NBLENBREgsT0FBaUIsWUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBM3dDZCw2RUFBQTs7QUFpeENBLENBREgsT0FBaUIsa0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh4Q2QsNkVBQUE7O0FBc3hDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXJ4Q2QsNkVBQUE7O0FBMnhDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTF4Q2QsNkVBQUE7O0FBZ3lDQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEveENkLDZFQUFBOztBQXF5Q0EsQ0FESCxPQUFpQixzQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHlDZCw2RUFBQTs7QUEweUNBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenlDZCw2RUFBQTs7QUEreUNBLENBREgsT0FBaUIsb0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl5Q2QsNkVBQUE7O0FBb3pDQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW56Q2QsNkVBQUE7O0FBeXpDQSxDQURILE9BQWlCLGtCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4ekNkLDZFQUFBOztBQTh6Q0EsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3ekNkLDZFQUFBOztBQW0wQ0EsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbDBDZCw2RUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBaStDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWgrQ2QsNkVBQUE7O0FBcytDQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXIrQ2QsNkVBQUE7O0FBMitDQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTErQ2QsNkVBQUE7O0FBZy9DQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQS8rQ2QsNkVBQUE7O0FBcS9DQSxDQURILE9BQWlCLE9BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXAvQ2QsNkVBQUE7O0FBMC9DQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXovQ2QsNkVBQUE7O0FBKy9DQSxDQURILE9BQWlCLE1BQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTkvQ2QsNkVBQUE7O0FBb2dEQSxDQURILE9BQWlCLFlBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5nRGQsNkVBQUE7O0FBeWdEQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhnRGQsNkVBQUE7O0FBOGdEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdnRGQsNkVBQUE7O0FBbWhEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxoRGQsNkVBQUE7O0FBd2hEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2aERkLDZFQUFBOztBQTZoREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1aERkLDZFQUFBOztBQWtpREEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBamlEZCw2RUFBQTs7QUF1aURBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBdGlEZCw2RUFBQTs7QUE0aURBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTNpRGQsNkVBQUE7O0FBaWpEQSxDQURILE9BQWlCLGFBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWhqRGQsNkVBQUE7O0FBc2pEQSxDQURILE9BQWlCLG1CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyakRkLDZFQUFBOztBQTJqREEsQ0FESCxPQUFpQixVQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExakRkLDZFQUFBOztBQWdrREEsQ0FESCxPQUFpQixnQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL2pEZCw2RUFBQTs7QUFxa0RBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcGtEZCw2RUFBQTs7QUEwa0RBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBemtEZCw2RUFBQTs7QUEra0RBLENBREgsT0FBaUIsV0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOWtEZCw2RUFBQTs7QUFvbERBLENBREgsT0FBaUIsaUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW5sRGQsNkVBQUE7O0FBeWxEQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXhsRGQsNkVBQUE7O0FBOGxEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTdsRGQsNkVBQUE7O0FBbW1EQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWxtRGQsNkVBQUE7O0FBd21EQSxDQURILE9BQWlCLGlCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2bURkLDZFQUFBOztBQTZtREEsQ0FESCxPQUFpQixTQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE1bURkLDZFQUFBOztBQWtuREEsQ0FESCxPQUFpQixlQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFqbkRkLDZFQUFBOztBQXVuREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF0bkRkLDZFQUFBOztBQTRuREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzbkRkLDZFQUFBOztBQWlvREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFob0RkLDZFQUFBOztBQXNvREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyb0RkLDZFQUFBOztBQTJvREEsQ0FESCxPQUFpQixPQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExb0RkLDZFQUFBOztBQWdwREEsQ0FESCxPQUFpQixhQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEvb0RkLDZFQUFBOztBQXFwREEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFwcERkLDZFQUFBOztBQTBwREEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF6cERkLDZFQUFBOztBQStwREEsQ0FESCxPQUFpQixNQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE5cERkLDZFQUFBOztBQW9xREEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFucURkLDZFQUFBOztBQXlxREEsQ0FESCxPQUFpQixLQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4cURkLDZFQUFBOztBQThxREEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUE3cURkLDZFQUFBOztBQW1yREEsQ0FESCxPQUFpQixRQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFsckRkLDZFQUFBOztBQXdyREEsQ0FESCxPQUFpQixjQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF2ckRkLDZFQUFBOztBQTZyREEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBNXJEZCw2RUFBQTs7QUFrc0RBLENBREgsT0FBaUIsd0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWpzRGQsNkVBQUE7O0FBdXNEQSxDQURILE9BQWlCLFVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXRzRGQsNkVBQUE7O0FBNHNEQSxDQURILE9BQWlCLGdCQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUEzc0RkLDZFQUFBOztBQWl0REEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFodERkLDZFQUFBOztBQXN0REEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcnREZCw2RUFBQTs7QUEydERBLENBREgsT0FBaUIsU0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBMXREZCw2RUFBQTs7QUFndURBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3REZCw2RUFBQTs7QUFxdURBLENBREgsT0FBaUIsYUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHVEZCw2RUFBQTs7QUEwdURBLENBREgsT0FBaUIsbUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXp1RGQsNkVBQUE7O0FBK3VEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTl1RGQsNkVBQUE7O0FBb3ZEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFudkRkLDZFQUFBOztBQXl2REEsQ0FESCxPQUFpQixZQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUF4dkRkLDZFQUFBOztBQTh2REEsQ0FESCxPQUFpQixrQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBN3ZEZCw2RUFBQTs7QUFtd0RBLENBREgsT0FBaUIsVUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBbHdEZCw2RUFBQTs7QUF3d0RBLENBREgsT0FBaUIsZ0JBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXZ3RGQsNkVBQUE7O0FBNndEQSxDQURILE9BQWlCLFNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTV3RGQsNkVBQUE7O0FBa3hEQSxDQURILE9BQWlCLGVBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWp4RGQsNkVBQUE7O0FBdXhEQSxDQURILE9BQWlCLEtBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQXR4RGQsNkVBQUE7O0FBNHhEQSxDQURILE9BQWlCLFdBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQTN4RGQsNkVBQUE7O0FBaXlEQSxDQURILE9BQWlCLGNBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQWh5RGQsNkVBQUE7O0FBc3lEQSxDQURILE9BQWlCLG9CQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUFyeURkLDZFQUFBOztBQTJ5REEsQ0FESCxPQUFpQixXQUNiO0VBQWUsU0FBUyxPQUFUOztBQUNoQixPQUFRLEVBRlgsT0FBaUI7RUExeURkLDZFQUFBOztBQWd6REEsQ0FESCxPQUFpQixpQkFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBL3lEZCw2RUFBQTs7QUFxekRBLENBREgsT0FBaUIsUUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBcHpEZCw2RUFBQTs7QUEwekRBLENBREgsT0FBaUIsY0FDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBenpEZCw2RUFBQTs7QUErekRBLENBREgsT0FBaUIsZUFDYjtFQUFlLFNBQVMsT0FBVDs7QUFDaEIsT0FBUSxFQUZYLE9BQWlCO0VBOXpEZCw2RUFBQTs7QUFvMERBLENBREgsT0FBaUIscUJBQ2I7RUFBZSxTQUFTLE9BQVQ7O0FBQ2hCLE9BQVEsRUFGWCxPQUFpQjtFQW4wRGQsNkVBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQ3NFSjtFQUVJLHFCQUFBO0VBQ0Esc0JBQUE7RUFDQSxzQkFBQTtFQUdBLFNBQUE7RUFDQSxxQkFBQTtFQUNBLFNBQUE7RUFFQSxzQkFBQTtFSDlEQSxxQ0FBQTtFQUNBLGtCQUFBO0VBQ0EsZ0JBQUE7RUcrREEsY0FBQTtFQUNBLG1CQUFBO0VBQ0EscUJBQUE7RUFFQSxlQUFBO0VBQ0EsaUNBQUE7RUFDQSx3QkFBQTs7QUpwRUEsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7RUFDSiw4QkFBQTs7QUdxRUo7QUFDQSxJQUFDO0FBQ0QsSUFBQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTs7QUFHSixJQUFDO0FBQ0QsSUFBQztFQUNHLHlCQUFBOztBQUdKLElBQUM7QUFDRCxJQUFDO0VBQ0cseUJBQUE7RUFDQSwyQkFBQTtFQUdBLG1CQUFBOztBQUdKLElBQUM7QUFDRCxJQUFDO0VBQ0cseUJBQUE7O0FBR0osTUFBTSxJQUFDO0FBQ1AsS0FBSyxJQUFDO0VBR0YsU0FBQTs7QUFHSixJQUFFO0VBQ0Usb0JBQUE7O0FBSVI7RUFLUSxxQ0FBQTs7QUFMUixPQVNJLE9BQU07QUFUVixPQVVJLE1BQUs7RUFDRCxpQkFBQTtFQUNBLGtCQUFBO0VBQ0EscUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBdUNKO0FBQ0EsZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTtFQUNBLGNBQUE7O0FBR0osZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTs7QUFHSixlQUFDO0FBQ0QsZUFBQztFQUNHLHlCQUFBO0VBQ0Esc0JBQUE7O0FBR0osZUFBQztBQUNELGVBQUM7RUFDRyx5QkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUErRko7QUFDQSxhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTs7QUFHSixhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBOztBQUdKLGFBQUM7QUFDRCxhQUFDO0VBQ0cseUJBQUE7RUFDQSxzQkFBQTs7QUFHSixhQUFDO0FBQ0QsYUFBQztFQUNHLHlCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQWtDSjtBQUFBLElBRkE7QUFHQSxjQUFDO0FBQUQsSUFIQSxVQUdDO0FBQ0QsY0FBQztBQUFELElBSkEsVUFJQztBQUNELGNBQUM7QUFBRCxJQUxBLFVBS0M7QUFDRCxjQUFDO0FBQUQsSUFOQSxVQU1DO0FBQ0QsY0FBQztBQUFELElBUEEsVUFPQztBQUNELGNBQUM7QUFBRCxJQVJBLFVBUUM7QUFDRCxjQUFDO0FBQUQsSUFUQSxVQVNDO0FBQ0QsY0FBQztBQUFELElBVkEsVUFVQztFQUNHLHlCQUFBO0VBQ0EsY0FBQTtFQUNBLGVBQUE7RUFDQSxtQkFBQTs7QUFHSixjQUFDO0FBQUQsSUFqQkEsVUFpQkM7QUFDRCxjQUFDO0FBQUQsSUFsQkEsVUFrQkM7RUFDRyxzQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFrQ1I7RUFFSSxrQ0FBQTtFQUdBLGtCQUFBOztBQUVBLFdBQUU7RUFDRSx5QkFBQTs7QUFLUixPQUlJLE9BQU07QUFKVixPQUtJLE1BQUs7RUFDRCx5QkFBQTtFQUNBLDRCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvSFI7RUFDSSx3QkFBQTtFQUNBLCtCQUFBO0VBQ0EsZ0RBQUE7RUFDQSxzQkFBQTs7QUFFQSxlQUFnQjtFQUNaLDJCQUFBO0VBQ0EsNENBQUE7O0FBRUosYUFBYztFQUNWLDJCQUFBO0VBQ0EsNENBQUE7O0FBRUosY0FBZTtBQUNmLElBQUksVUFBVztFQUNYLDJCQUFBO0VBQ0EsNENBQUE7O0FBSVI7RUFDSSx3QkFBQTtFQUNBLGVBQUE7RUFDQSw4QkFBQTtFQUNBLCtDQUFBO0VBQ0Esc0JBQUE7O0FBRUEsZUFBZ0I7RUFDWiwwQkFBQTtFQUNBLDJDQUFBOztBQUVKLGFBQWM7RUFDViwwQkFBQTtFQUNBLDJDQUFBOztBQUVKLGNBQWU7QUFDZixJQUFJLFVBQVc7RUFDWCwwQkFBQTtFQUNBLDJDQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUEyQ1I7RUFVUSxnQkFBQTs7QUFOSixhQUFDO0VBQ0csMEJBQUE7RUFDQSw2QkFBQTs7QUFPSixhQUFDO0VBQ0cseUJBQUE7RUFDQSw0QkFBQTs7QUFLSixhQUFDLE1BQU87QUFDUixhQUFDLE1BQU8sZ0JBQUc7QUFDWDtBQUNBLGFBQUU7QUFDRixhQUFDO0FBQ0QsYUFBRSxnQkFBRztFQUNELHNCQUFBOztBQUdKLGFBQUMsTUFBTSxXQUFZLGdCQUFHO0FBQ3RCLGFBQUMsTUFBTSxXQUFZLGdCQUFHLEtBQUs7QUFDM0IsYUFBQztBQUNELGFBQUMsS0FBSztBQUNOLGFBQUMsV0FBWSxnQkFBRztBQUNoQixhQUFDLFdBQVksZ0JBQUcsS0FBSztFQUNqQiwwQkFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBd0ZKO0FBQ0EscUJBQUM7QUFDRCxxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDO0FBQ0QscUJBQUM7QUFDRCxxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDO0VBQ0cseUJBQUE7O0FBR0oscUJBQUMsZUFBZTtBQUNoQixxQkFBQyxlQUFlO0FBQ2hCLHFCQUFDLGVBQWU7RUFDWix5QkFBQTs7QUFHSixxQkFBQztFQUNHLHlCQUFBOztBQUdKLHFCQUFDLGFBQWE7QUFDZCxxQkFBQyxhQUFhO0FBQ2QscUJBQUMsYUFBYTtFQUNWLHlCQUFBOztBQUdKLHFCQUFDO0FBQ0QscUJBQUMsY0FBYztBQUNmLHFCQUFDLGNBQWM7QUFDZixxQkFBQyxjQUFjO0FBQ2YscUJBQUM7QUFDRCxxQkFBQyxVQUFVO0FBQ1gscUJBQUMsVUFBVTtBQUNYLHFCQUFDLFVBQVU7RUFDUCx5QkFBQTs7QUFHSixxQkFBQztFQUNHLDBCQUFBO0VBQ0EsMkJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O0FBcUNSO0VBRUksVUFBQTtFQUNBLGlDQUFBO0VBQ0EsZ0JBQUE7RUFHQSxlQUFBOztBQUVBO0FBQ0EsVUFBQztBQUNELFVBQUM7RUFDRyw0QkFBQTtFQUNBLDZCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQUFDO0FBQ0QsVUFBQztFQUNHLGdDQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBQUM7QUFDRCxVQUFDO0VBQ0csMEJBQUE7RUFDQSw2QkFBQTtFQUNBLDRCQUFBOztBQUdKLFVBQUM7QUFDRCxVQUFDO0VBQ0csZ0NBQUE7RUFDQSw2QkFBQTtFQUNBLGNBQUE7O0FBS1IsT0FFSSxPQUFNO0FBRlYsT0FHSSxNQUFLO0VBQ0QsVUFBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1Q0osVUFGTTtBQUdOLFVBSE0sZUFHTDtBQUNELFVBSk0sZUFJTDtFQUNHLDRCQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBVk0sZUFVTDtBQUNELFVBWE0sZUFXTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQWhCTSxlQWdCTDtBQUNELFVBakJNLGVBaUJMO0VBQ0csc0JBQUE7O0FBR0osVUFyQk0sZUFxQkw7QUFDRCxVQXRCTSxlQXNCTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUF1Q0osVUFGTTtBQUdOLFVBSE0sYUFHTDtBQUNELFVBSk0sYUFJTDtFQUNHLDRCQUFBO0VBQ0EsNkJBQUE7RUFDQSxjQUFBOztBQUdKLFVBVk0sYUFVTDtBQUNELFVBWE0sYUFXTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7QUFHSixVQWhCTSxhQWdCTDtBQUNELFVBakJNLGFBaUJMO0VBQ0csc0JBQUE7O0FBR0osVUFyQk0sYUFxQkw7QUFDRCxVQXRCTSxhQXNCTDtFQUNHLDRCQUFBO0VBQ0EsY0FBQTs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUM5OEJSO0VKV0kscUNBQUE7RUFDQSxrQkFBQTtFQUNBLGlCQUFBO0VBdUdBLDJCQUFBO0VBQ0Esa0JBQUE7RUFDQSxtQkFBQTtFQUNBLGlCQUFBO0VBQ0EseUJBQUE7RUl0SEEsMkJBQUE7O0FMWUEsT0FBUTtFQUNKLDhCQUFBOztBQ0RKLE9BQVE7RUFDSiw4QkFBQTs7QURESixPQUFRO0VBQ0osOEJBQUE7O0FDREosT0FBUTtFQUNKLDhCQUFBOzs7Ozs7Ozs7Ozs7Ozs7QUlNSixhQUFDO0FBQ0QsYUFBQztBQUNELGFBQUM7QUFDRCxhQUFDO0FBQ0QsYUFBQztBQUNELGFBQUM7RUFDRyxxQkFBQTtFQUNBLGtCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBQWtESixLQVJDLGFBUUE7QUFBRCxLQVBDLGVBT0E7QUFBRCxLQU5DLGNBTUE7QUFBRCxLQUxDLFlBS0E7QUFBRCxLQUpDLFlBSUE7QUFBRCxLQUhDLGVBR0E7QUFBRCxNQUZFLFVBRUQ7QUFBRCxRQUFDO0VBQ0cseUJBQUE7RUFDQSwwQkFBQTs7QUFFSixLQVpDLGFBWUE7QUFBRCxLQVhDLGVBV0E7QUFBRCxLQVZDLGNBVUE7QUFBRCxLQVRDLFlBU0E7QUFBRCxLQVJDLFlBUUE7QUFBRCxLQVBDLGVBT0E7QUFBRCxNQU5FLFVBTUQ7QUFBRCxRQUFDO0VBQ0cseUJBQUE7RUFDQSwwQkFBQTs7QUFFSixLQWhCQyxhQWdCQTtBQUFELEtBZkMsZUFlQTtBQUFELEtBZEMsY0FjQTtBQUFELEtBYkMsWUFhQTtBQUFELEtBWkMsWUFZQTtBQUFELEtBWEMsZUFXQTtBQUFELE1BVkUsVUFVRDtBQUFELFFBQUM7RUFDRyx5QkFBQTtFQUNBLDBCQUFBOztBQUVKLEtBcEJDLGFBb0JBO0FBQUQsS0FuQkMsZUFtQkE7QUFBRCxLQWxCQyxjQWtCQTtBQUFELEtBakJDLFlBaUJBO0FBQUQsS0FoQkMsWUFnQkE7QUFBRCxLQWZDLGVBZUE7QUFBRCxNQWRFLFVBY0Q7QUFBRCxRQUFDO0VBQ0cseUJBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvRFIsQ0FBQztFQUdHLGtCQUFBO0VBQ0EsVUFBQTtFQUNBLGtCQUFBO0VBQ0EsaUJBQUE7O0FBR0osTUFBTyxJQUFHO0VBQ04sY0FBQTs7QUFHSixRQUFTLElBQUc7RUFDUixjQUFBOztBQUdKLFFBQVMsSUFBRztFQUNSLGNBQUE7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFxRkosV0FBWTtFQUNSLG1CQUFBOztBQUdKLGdCQUFpQjtFQUNiLG9CQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7OztBUHBQSixxQkFIMEM7RUFHMUM7SVE0UUUsY0FBQTtJQUNBLGtCQUFBO0lBQ0Esa0JBQUE7SUFDQSxtQkFBQTs7O0FQL1FGLHFCQUgwQztFQUcxQztJTzRRRSxjQUFBO0lBQ0Esa0JBQUE7SUFDQSxrQkFBQTtJQUNBLG1CQUFBOzs7QURXRSxlQUFDO0VBQ0csdUJBQUE7O0FQM1JSLHFCQUgwQztFQUcxQyxlTzBSSztJQ3BPSCxxQkFBQTtJQUNBLDhCQUFBO0lBQ0csMkJBQUE7SUFDSyxzQkFBQTtJQVlSLHlCQUFBO0lBQ0Esb0JBQUE7SUFHQSxxQkFBQTtJQUVBLG1CQUFBO0lBOEJFLFVBQUE7SURxTFEscUJBQUE7O0VDak5WLE9BQVEsZ0JENk1MO0lDM01ELGVBQUE7SUFHQSxlQUFBO0lBR0EsT0FBQTtJQUVBLGNBQWMsMENBQWQ7OztBUHZGSixxQkFIMEM7RUFHMUMsZU0wUks7SUNwT0gscUJBQUE7SUFDQSw4QkFBQTtJQUNHLDJCQUFBO0lBQ0ssc0JBQUE7SUFZUix5QkFBQTtJQUNBLG9CQUFBO0lBR0EscUJBQUE7SUFFQSxtQkFBQTtJQThCRSxVQUFBO0lEcUxRLHFCQUFBOztFQ2pOVixPQUFRLGdCRDZNTDtJQzNNRCxlQUFBO0lBR0EsZUFBQTtJQUdBLE9BQUE7SUFFQSxjQUFjLDBDQUFkOzs7QVJ2RkoscUJBSDBDO0VBRzFDLGVPMFJLO0lDcE9ILHFCQUFBO0lBQ0EsOEJBQUE7SUFDRywyQkFBQTtJQUNLLHNCQUFBO0lBWVIseUJBQUE7SUFDQSxvQkFBQTtJQUdBLHFCQUFBO0lBRUEsbUJBQUE7SUE4QkUsbUJBQUE7SUR5TFEscUJBQUE7O0VDck5WLE9BQVEsZ0JENk1MO0lDM01ELGVBQUE7SUFHQSxlQUFBO0lBR0EsT0FBQTtJQUVBLGNBQWMsMENBQWQ7OztBUHZGSixxQkFIMEM7RUFHMUMsZU0wUks7SUNwT0gscUJBQUE7SUFDQSw4QkFBQTtJQUNHLDJCQUFBO0lBQ0ssc0JBQUE7SUFZUix5QkFBQTtJQUNBLG9CQUFBO0lBR0EscUJBQUE7SUFFQSxtQkFBQTtJQThCRSxtQkFBQTtJRHlMUSxxQkFBQTs7RUNyTlYsT0FBUSxnQkQ2TUw7SUMzTUQsZUFBQTtJQUdBLGVBQUE7SUFHQSxPQUFBO0lBRUEsY0FBYywwQ0FBZDs7O0FEbU1BLGVBQUMsTUFXRztFQUNJLHNCQUFBO0VBQ0EsV0FBQTs7QUFJUixlQUFDO0VBQ0csdUJBQUE7O0FQNVNSLHFCQUgwQztFQUcxQyxlTzJTSztJQ3JQSCxxQkFBQTtJQUNBLDhCQUFBO0lBQ0csMkJBQUE7SUFDSyxzQkFBQTtJQVlSLHlCQUFBO0lBQ0Esb0JBQUE7SUFHQSxxQkFBQTtJQUVBLG1CQUFBO0lBOEJFLFVBQUE7O0VBNUJGLE9BQVEsZ0JEOE5MO0lDNU5ELGVBQUE7SUFHQSxlQUFBO0lBR0EsT0FBQTtJQUVBLGNBQWMsMENBQWQ7OztBUHZGSixxQkFIMEM7RUFHMUMsZU0yU0s7SUNyUEgscUJBQUE7SUFDQSw4QkFBQTtJQUNHLDJCQUFBO0lBQ0ssc0JBQUE7SUFZUix5QkFBQTtJQUNBLG9CQUFBO0lBR0EscUJBQUE7SUFFQSxtQkFBQTtJQThCRSxVQUFBOztFQTVCRixPQUFRLGdCRDhOTDtJQzVORCxlQUFBO0lBR0EsZUFBQTtJQUdBLE9BQUE7SUFFQSxjQUFjLDBDQUFkOzs7QVJ2RkoscUJBSDBDO0VBRzFDLGVPMlNLO0lDclBILHFCQUFBO0lBQ0EsOEJBQUE7SUFDRywyQkFBQTtJQUNLLHNCQUFBO0lBWVIseUJBQUE7SUFDQSxvQkFBQTtJQUdBLHFCQUFBO0lBRUEsbUJBQUE7SUE4QkUsbUJBQUE7O0VBNUJGLE9BQVEsZ0JEOE5MO0lDNU5ELGVBQUE7SUFHQSxlQUFBO0lBR0EsT0FBQTtJQUVBLGNBQWMsMENBQWQ7OztBUHZGSixxQkFIMEM7RUFHMUMsZU0yU0s7SUNyUEgscUJBQUE7SUFDQSw4QkFBQTtJQUNHLDJCQUFBO0lBQ0ssc0JBQUE7SUFZUix5QkFBQTtJQUNBLG9CQUFBO0lBR0EscUJBQUE7SUFFQSxtQkFBQTtJQThCRSxtQkFBQTs7RUE1QkYsT0FBUSxnQkQ4Tkw7SUM1TkQsZUFBQTtJQUdBLGVBQUE7SUFHQSxPQUFBO0lBRUEsY0FBYywwQ0FBZDs7O0FEb05BLGVBQUMsSUFVRztFQUNJLHNCQUFBO0VBQ0EsV0FBQTs7QUFaUixlQUFDLElBZUc7RUFDSSwwQkFBQTtFQUNBLDJCQUFBOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7QUFvQ1o7RUFFSSxrQkFBQTs7QUFGSixpQkFJSSxNQUFLO0FBSlQsaUJBS0ksTUFBSztBQUxULGlCQU1JLE1BQUs7QUFOVCxpQkFPSSxNQUFLO0FBUFQsaUJBUUksTUFBSztBQVJULGlCQVNJLE1BQUs7RUFDRCxzQkFBQTtFQUNBLFdBQUE7RUFDQSx1QkFBQTs7QUFFQSxpQkFWSixNQUFLLGFBVUE7QUFBRCxpQkFUSixNQUFLLGVBU0E7QUFBRCxpQkFSSixNQUFLLGNBUUE7QUFBRCxpQkFQSixNQUFLLFlBT0E7QUFBRCxpQkFOSixNQUFLLFlBTUE7QUFBRCxpQkFMSixNQUFLLGVBS0E7RUFDRyxrQkFBQTs7QUFmWixpQkFtQkk7RVJpQ0EsaUNBQUE7RVEvQkksa0JBQUE7RUFDQSxlQUFBO0VBQ0EsTUFBQTs7O0FBRUEsaUJBTkosS0FNSztFQUNHLG1CQUFBOztBQUlKLGlCQVhKLEtBV0ssTUFBTTtFQUNILHNCQUFBIn0= */

--- a/src/cf-forms.less
+++ b/src/cf-forms.less
@@ -65,7 +65,7 @@
 */
 
 .form-label-header {
-    .h5();
+    .heading-5();
     margin-bottom: unit(10px / @font-size, em);
 }
 


### PR DESCRIPTION
Updated for the new heading changes in cf-core
## Additions
- None
## Removals
- None
## Changes
- Changed `.h#()` mixins to `.heading-#()` to avoid over-writing top-margin
- Removed visually tweaked margins
## Review
- @Scotchester 
- @KimberlyMunoz 
- @cfarm 
- @ascott1 
## Notes
- .h# mixins should no longer be used if default margin mixes aren't required, use .heading-# instead
- We're no longer tweaking margins by eye, use the default margin for headings unless necessary, such as the header-slug
## Checklist
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
- [ ] Passes all existing automated tests
- [ ] New functions include new tests
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged
- [ ] Visually tested in supported browsers and devices 
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
